### PR TITLE
feat: add `SaveRepository` use case

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/SaveOrganization.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/SaveOrganization.java
@@ -1,0 +1,26 @@
+package io.pakland.mdas.githubstats.application;
+
+import io.pakland.mdas.githubstats.domain.Organization;
+import io.pakland.mdas.githubstats.domain.repository.OrganizationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class SaveOrganization {
+    public final OrganizationRepository organizationRepository;
+
+    public SaveOrganization(OrganizationRepository repository) {
+        this.organizationRepository = repository;
+    }
+
+    @Transactional
+    public void execute(Organization organization) {
+        Optional<Organization> found = organizationRepository.findById(organization.getId());
+        if (found.isPresent()) {
+            return;
+        }
+        organizationRepository.save(organization);
+    }
+}

--- a/src/test/java/io/pakland/mdas/githubstats/application/SaveOrganizationTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/SaveOrganizationTest.java
@@ -1,0 +1,36 @@
+package io.pakland.mdas.githubstats.application;
+
+import io.pakland.mdas.githubstats.domain.Organization;
+import io.pakland.mdas.githubstats.domain.repository.OrganizationRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+public class SaveOrganizationTest {
+    @Test
+    public void shouldSaveOrganization_whenDoesNotExist() {
+        Organization organization = new Organization();
+        organization.setId(1L);
+        OrganizationRepository orgRepositoryMock = Mockito.mock(OrganizationRepository.class);
+        Mockito.when(orgRepositoryMock.findById(Mockito.anyLong())).thenReturn(Optional.empty());
+
+        new SaveOrganization(orgRepositoryMock).execute(organization);
+
+        Mockito.verify(orgRepositoryMock, Mockito.times(1)).findById(1L);
+        Mockito.verify(orgRepositoryMock, Mockito.times(1)).save(organization);
+    }
+
+    @Test
+    public void shouldNotSaveOrganization_wheDoesExist() {
+        Organization organization = new Organization();
+        organization.setId(1L);
+        OrganizationRepository orgRepositoryMock = Mockito.mock(OrganizationRepository.class);
+        Mockito.when(orgRepositoryMock.findById(Mockito.anyLong())).thenReturn(Optional.of(organization));
+
+        new SaveOrganization(orgRepositoryMock).execute(organization);
+
+        Mockito.verify(orgRepositoryMock, Mockito.times(1)).findById(1L);
+        Mockito.verify(orgRepositoryMock, Mockito.times(0)).save(Mockito.any(Organization.class));
+    }
+}


### PR DESCRIPTION
Added the `SaveRepository` use case. Since we have not defined what to do when entities exist, as a first implementation, I have opted not to save an entity if such exists.

Closes #55.