### PR TITLE
feat: fetch teams from organization user case

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/TeamDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/TeamDTO.java
@@ -1,0 +1,17 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TeamDTO {
+    @JsonProperty("id")
+    private Integer id;
+
+    @JsonProperty("slug")
+    private String slug;
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/rest/repository/adapters/TeamRESTRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/rest/repository/adapters/TeamRESTRepository.java
@@ -1,0 +1,40 @@
+package io.pakland.mdas.githubstats.infrastructure.rest.repository.adapters;
+
+import io.pakland.mdas.githubstats.application.dto.TeamDTO;
+import io.pakland.mdas.githubstats.infrastructure.rest.repository.WebClientConfiguration;
+import io.pakland.mdas.githubstats.infrastructure.rest.repository.ports.ITeamRESTRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+
+public class TeamRESTRepository implements ITeamRESTRepository {
+
+    private final WebClientConfiguration webClientConfiguration;
+    Logger logger = LoggerFactory.getLogger(TeamRESTRepository.class);
+
+    public TeamRESTRepository(WebClientConfiguration webClientConfiguration) {
+        this.webClientConfiguration = webClientConfiguration;
+    }
+
+    @Override
+    public List<TeamDTO> fetchTeamsFromOrganization(String organizationName) {
+        try {
+            return this.webClientConfiguration.getWebClient().get()
+                    .uri(String.format("/orgs/%s/teams", organizationName))
+                    .retrieve()
+                    .bodyToFlux(TeamDTO.class)
+                    .collectList()
+                    .block();
+        } catch (WebClientResponseException ex) {
+            // TODO: How do we prettend to handle exceptions?
+            logger.error(ex.toString());
+            throw ex;
+        } catch (Exception ex) {
+            logger.error(ex.toString());
+            // TODO: How do we prettend to handle exceptions?
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/rest/repository/ports/ITeamRESTRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/rest/repository/ports/ITeamRESTRepository.java
@@ -1,0 +1,9 @@
+package io.pakland.mdas.githubstats.infrastructure.rest.repository.ports;
+
+import io.pakland.mdas.githubstats.application.dto.TeamDTO;
+
+import java.util.List;
+
+public interface ITeamRESTRepository {
+    List<TeamDTO> fetchTeamsFromOrganization(String organizationName);
+}

--- a/src/test/java/io/pakland/mdas/githubstats/infrastructure/rest/repository/TeamRESTRepositoryTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/infrastructure/rest/repository/TeamRESTRepositoryTest.java
@@ -1,0 +1,73 @@
+package io.pakland.mdas.githubstats.infrastructure.rest.repository;
+
+import io.pakland.mdas.githubstats.application.dto.TeamDTO;
+import io.pakland.mdas.githubstats.infrastructure.rest.repository.adapters.TeamRESTRepository;
+import io.pakland.mdas.githubstats.infrastructure.rest.repository.adapters.UserRESTRepository;
+import io.pakland.mdas.githubstats.application.dto.UserDTO;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TeamRESTRepositoryTest {
+    private MockWebServer mockWebServer;
+    private TeamRESTRepository teamRESTRepository;
+    private String organizationTeamsListResponse;
+
+    @BeforeAll
+    void setup() throws IOException {
+        this.mockWebServer = new MockWebServer();
+        this.mockWebServer.start();
+        WebClientConfiguration webClientConfiguration = new WebClientConfiguration(mockWebServer.url("/").toString(), "test-api-key");
+        this.teamRESTRepository = new TeamRESTRepository(webClientConfiguration);
+        this.organizationTeamsListResponse = new String(Files.readAllBytes(Paths.get("src/test/java/io/pakland/mdas/githubstats/infrastructure/rest/repository/responses/OrganizationTeams.json")));
+    }
+
+    @AfterAll
+    void shutDown() throws IOException {
+        this.mockWebServer.shutdown();
+    }
+
+    @Test
+    void givenValidTeamMembersRequest_shouldCallTeamMembersEndpoint() throws InterruptedException {
+        MockResponse mockResponse = new MockResponse()
+                .setBody(this.organizationTeamsListResponse)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        mockWebServer.enqueue(mockResponse);
+
+        teamRESTRepository.fetchTeamsFromOrganization("github-stats-22");
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertEquals(String.format("/orgs/%s/teams", "github-stats-22"), request.getPath());
+    }
+
+    @Test
+    void givenValidTeamId_shouldReturnTeamMembers() {
+
+        MockResponse mockResponse = new MockResponse()
+                .setBody(this.organizationTeamsListResponse)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        mockWebServer.enqueue(mockResponse);
+
+        List<TeamDTO> response = teamRESTRepository.fetchTeamsFromOrganization("github-stats-22");
+        List<TeamDTO> expected = new ArrayList<>();
+        expected.add(0, new TeamDTO(7098104, "gs-developers"));
+
+        assertEquals(response.size(), 1);
+        assertArrayEquals(response.toArray(), expected.toArray());
+    }
+}

--- a/src/test/java/io/pakland/mdas/githubstats/infrastructure/rest/repository/responses/OrganizationTeams.json
+++ b/src/test/java/io/pakland/mdas/githubstats/infrastructure/rest/repository/responses/OrganizationTeams.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "gs-developers",
+    "id": 7098104,
+    "node_id": "T_kwDOByX9DM4AbE74",
+    "slug": "gs-developers",
+    "description": "Maintainers of GithubStats",
+    "privacy": "closed",
+    "url": "https://api.github.com/organizations/119930124/team/7098104",
+    "html_url": "https://github.com/orgs/github-stats-22/teams/gs-developers",
+    "members_url": "https://api.github.com/organizations/119930124/team/7098104/members{/member}",
+    "repositories_url": "https://api.github.com/organizations/119930124/team/7098104/repos",
+    "permission": "pull",
+    "parent": null
+  }
+]


### PR DESCRIPTION
Given an organization name we want to fetch all of its teams from the Github API. In order to do that, I've used the WebClient.

closes #59 