### PR TITLE
feat: `fetchPullRequestsFromRepository` use case

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/FetchPullRequestsFromRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/FetchPullRequestsFromRepository.java
@@ -1,0 +1,20 @@
+package io.pakland.mdas.githubstats.application;
+
+import io.pakland.mdas.githubstats.application.dto.PullRequestDTO;
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.domain.repository.PullRequestExternalRepository;
+
+import java.util.List;
+
+public class FetchPullRequestsFromRepository {
+
+    private PullRequestExternalRepository pullRequestExternalRepository;
+
+    public FetchPullRequestsFromRepository(PullRequestExternalRepository pullRequestExternalRepository) {
+        this.pullRequestExternalRepository = pullRequestExternalRepository;
+    }
+
+    public List<PullRequestDTO> execute(Integer repositoryOwnerId, Integer repositoryId) throws HttpException {
+        return this.pullRequestExternalRepository.fetchPullRequestsFromRepository(repositoryOwnerId, repositoryId);
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/OrganizationDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/OrganizationDTO.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -14,4 +16,6 @@ public class OrganizationDTO {
 
     @JsonProperty("login")
     private String login;
+
+    private List<TeamDTO> teams;
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/RepositoryDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/RepositoryDTO.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -14,4 +16,9 @@ public class RepositoryDTO {
 
     @JsonProperty("name")
     private String name;
+
+    @JsonProperty("owner.id")
+    private Integer repositoryOwnerId;
+
+    private List<PullRequestDTO> pullRequests;
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/TeamDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/TeamDTO.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -12,9 +14,10 @@ public class TeamDTO {
     @JsonProperty("id")
     private Integer id;
 
-    @JsonProperty("name")
-    private String name;
-
     @JsonProperty("slug")
     private String slug;
+
+    private List<UserDTO> users;
+
+    private List<RepositoryDTO> repositories;
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
@@ -22,6 +22,7 @@ public class Team {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Integer id;
 
+  @Column(name = "slug")
   private String slug;
 
   @Column(name = "member_url")

--- a/src/main/java/io/pakland/mdas/githubstats/domain/repository/PullRequestExternalRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/repository/PullRequestExternalRepository.java
@@ -1,0 +1,10 @@
+package io.pakland.mdas.githubstats.domain.repository;
+
+import io.pakland.mdas.githubstats.application.dto.PullRequestDTO;
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+
+import java.util.List;
+
+public interface PullRequestExternalRepository {
+    public List<PullRequestDTO> fetchPullRequestsFromRepository(Integer repositoryOwnerId, Integer repositoryId) throws HttpException;
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/repository/PullRequestRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/repository/PullRequestRepository.java
@@ -4,11 +4,6 @@ import io.pakland.mdas.githubstats.domain.PullRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-/**
- * Add jdoc about the rep
- */
-
-
 @Repository
-public interface PullRequestsRepository extends JpaRepository<PullRequest,Integer> {
+public interface PullRequestRepository extends JpaRepository<PullRequest,Integer> {
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/PullRequestGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/PullRequestGitHubRepository.java
@@ -1,0 +1,35 @@
+package io.pakland.mdas.githubstats.infrastructure.github.repository;
+
+import io.pakland.mdas.githubstats.application.dto.PullRequestDTO;
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.domain.repository.PullRequestExternalRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+
+public class PullRequestGitHubRepository implements PullRequestExternalRepository {
+
+    private final WebClientConfiguration webClientConfiguration;
+    private final Logger logger = LoggerFactory.getLogger(PullRequestGitHubRepository.class);
+
+    public PullRequestGitHubRepository(WebClientConfiguration webClientConfiguration) {
+        this.webClientConfiguration = webClientConfiguration;
+    }
+
+    @Override
+    public List<PullRequestDTO> fetchPullRequestsFromRepository(Integer repositoryOwnerId, Integer repositoryId) throws HttpException {
+        try {
+            return this.webClientConfiguration.getWebClient().get()
+                    .uri(String.format("/organizations/%d/team/%d/repos", repositoryOwnerId, repositoryId))
+                    .retrieve()
+                    .bodyToFlux(PullRequestDTO.class)
+                    .collectList()
+                    .block();
+        } catch (WebClientResponseException ex) {
+            logger.error(ex.toString());
+            throw new HttpException(ex.getRawStatusCode(), ex.getMessage());
+        }
+    }
+}

--- a/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/OrganizationGitHubRepositoryTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/OrganizationGitHubRepositoryTest.java
@@ -28,6 +28,9 @@ class OrganizationGitHubRepositoryTest {
     private OrganizationGitHubRepository organizationGithubRepository;
     private String availableOrganizationsListResponse;
 
+    private final Integer organizationId = 119930124;
+    private final Integer teamId = 7098104;
+
     @BeforeAll
     void setup() throws IOException {
         this.mockWebServer = new MockWebServer();
@@ -65,7 +68,7 @@ class OrganizationGitHubRepositoryTest {
 
         List<OrganizationDTO> response = organizationGithubRepository.fetchAvailableOrganizations();
         List<OrganizationDTO> expected = new ArrayList<>();
-        expected.add(new OrganizationDTO(119930124, "github-stats-22"));
+        expected.add(new OrganizationDTO(this.organizationId, "github-stats-22", null));
 
         assertArrayEquals(response.toArray(), expected.toArray());
     }

--- a/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepositoryTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepositoryTest.java
@@ -1,6 +1,8 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
+import io.pakland.mdas.githubstats.application.dto.RepositoryDTO;
 import io.pakland.mdas.githubstats.application.dto.TeamDTO;
+import io.pakland.mdas.githubstats.application.dto.UserDTO;
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -26,7 +28,8 @@ class TeamGitHubRepositoryTest {
     private TeamGitHubRepository teamGitHubRepository;
     private String organizationTeamsListResponse;
 
-    private final Integer orgId = 119930124;
+    private final Integer organizationId = 119930124;
+    private final Integer teamId = 7098104;
 
     @BeforeAll
     void setup() throws IOException {
@@ -49,23 +52,22 @@ class TeamGitHubRepositoryTest {
                 .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         mockWebServer.enqueue(mockResponse);
 
-        teamGitHubRepository.fetchTeamsFromOrganization(orgId);
+        teamGitHubRepository.fetchTeamsFromOrganization(this.organizationId);
 
         RecordedRequest request = mockWebServer.takeRequest();
-        assertEquals(String.format("/orgs/%d/teams", orgId), request.getPath());
+        assertEquals(String.format("/orgs/%d/teams", this.organizationId), request.getPath());
     }
 
     @Test
     void givenValidTeamId_shouldReturnTeamMembers() throws HttpException {
-        Integer teamId = 7098104;
         MockResponse mockResponse = new MockResponse()
                 .setBody(this.organizationTeamsListResponse)
                 .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         mockWebServer.enqueue(mockResponse);
 
-        List<TeamDTO> response = teamGitHubRepository.fetchTeamsFromOrganization(orgId);
+        List<TeamDTO> response = teamGitHubRepository.fetchTeamsFromOrganization(this.organizationId);
         List<TeamDTO> expected = new ArrayList<>();
-        expected.add(0, new TeamDTO(teamId, "gs-developers", "gs-developers"));
+        expected.add(0, new TeamDTO(this.teamId, "gs-developers", null, null));
 
         assertEquals(response.size(), 1);
         assertArrayEquals(response.toArray(), expected.toArray());

--- a/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/UserGitHubRepositoryTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/UserGitHubRepositoryTest.java
@@ -26,7 +26,7 @@ class UserGitHubRepositoryTest {
     private UserGitHubRepository userGitHubRepository;
     private String teamMembersListResponse;
 
-    private final Integer orgId = 119930124;
+    private final Integer organizationId = 119930124;
     private final Integer teamId = 7098104;
 
     @BeforeAll
@@ -50,10 +50,10 @@ class UserGitHubRepositoryTest {
                 .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         mockWebServer.enqueue(mockResponse);
 
-        userGitHubRepository.fetchUsersFromTeam(orgId, teamId);
+        userGitHubRepository.fetchUsersFromTeam(this.organizationId, this.teamId);
 
         RecordedRequest request = mockWebServer.takeRequest();
-        assertEquals(String.format("/orgs/%d/teams/%d/members", orgId, teamId), request.getPath());
+        assertEquals(String.format("/orgs/%d/teams/%d/members", this.organizationId, this.teamId), request.getPath());
     }
 
     @Test
@@ -64,7 +64,7 @@ class UserGitHubRepositoryTest {
                 .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         mockWebServer.enqueue(mockResponse);
 
-        List<UserDTO> response = userGitHubRepository.fetchUsersFromTeam(orgId, teamId);
+        List<UserDTO> response = userGitHubRepository.fetchUsersFromTeam(this.organizationId, this.teamId);
         List<UserDTO> expected = new ArrayList<>();
         expected.add(0, new UserDTO(33031570, "manerow", "https://api.github.com/users/manerow/orgs"));
         expected.add(1, new UserDTO(48334745, "mikededo", "https://api.github.com/users/mikededo/orgs"));


### PR DESCRIPTION
- Proposal to remove the use of entities on the controller and only manage DTOs. 
- Add the fetch pull requests from a repository use case.

I'll later make a PR removing the use of DTOs as they are holding the same information as our domain entities. There is no need of DTOs under my opinion, also it will reduce the app complexity removing the need of mappers. 
I've analyzed the clean code kata we did on classroom (weather-kata-php) and the teacher didn't use DTOs for the responses of the httpClient.