### PR TITLE
fix: add missing @service spring annotation

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/FetchAvailableOrganizations.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/FetchAvailableOrganizations.java
@@ -3,9 +3,11 @@ package io.pakland.mdas.githubstats.application;
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import io.pakland.mdas.githubstats.domain.Organization;
 import io.pakland.mdas.githubstats.domain.repository.OrganizationExternalRepository;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Service
 public class FetchAvailableOrganizations {
 
     private final OrganizationExternalRepository organizationExternalRepository;

--- a/src/main/java/io/pakland/mdas/githubstats/application/FetchPullRequestsFromRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/FetchPullRequestsFromRepository.java
@@ -5,9 +5,12 @@ import io.pakland.mdas.githubstats.domain.PullRequest;
 import io.pakland.mdas.githubstats.domain.PullRequestState;
 import io.pakland.mdas.githubstats.domain.repository.PullRequestExternalRepository;
 import io.pakland.mdas.githubstats.domain.repository.PullRequestExternalRepository.FetchPullRequestFromRepositoryRequest;
+import org.springframework.stereotype.Service;
+
 import java.util.ArrayList;
 import java.util.List;
 
+@Service
 public class FetchPullRequestsFromRepository {
 
     private final PullRequestExternalRepository pullRequestExternalRepository;

--- a/src/main/java/io/pakland/mdas/githubstats/application/FetchRepositoriesFromTeam.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/FetchRepositoriesFromTeam.java
@@ -3,9 +3,11 @@ package io.pakland.mdas.githubstats.application;
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import io.pakland.mdas.githubstats.domain.Repository;
 import io.pakland.mdas.githubstats.domain.repository.RepositoryExternalRepository;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Service
 public class FetchRepositoriesFromTeam {
 
     private final RepositoryExternalRepository repositoryExternalRepository;

--- a/src/main/java/io/pakland/mdas/githubstats/application/FetchTeamsFromOrganization.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/FetchTeamsFromOrganization.java
@@ -3,9 +3,11 @@ package io.pakland.mdas.githubstats.application;
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import io.pakland.mdas.githubstats.domain.Team;
 import io.pakland.mdas.githubstats.domain.repository.TeamExternalRepository;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Service
 public class FetchTeamsFromOrganization {
     private final TeamExternalRepository teamExternalRepository;
 

--- a/src/main/java/io/pakland/mdas/githubstats/application/SaveAllCommits.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/SaveAllCommits.java
@@ -2,10 +2,12 @@ package io.pakland.mdas.githubstats.application;
 
 import io.pakland.mdas.githubstats.domain.Commit;
 import io.pakland.mdas.githubstats.domain.repository.CommitRepository;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Service
 public class SaveAllCommits {
 
     private final CommitRepository commitRepository;


### PR DESCRIPTION
All use cases should be annotated with spring @service, to create a bean component and make them singleton and injectable in other classes.