### PR TITLE
fix: change entity association in `UserOptionController`

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/GetRepositoriesByTeam.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/GetRepositoriesByTeam.java
@@ -14,7 +14,7 @@ public class GetRepositoriesByTeam {
 
     @Transactional
     public List<Repository> execute(Team team) {
-        return team.getRepositories();
+        return team.getRepositories().stream().toList();
     }
 
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/GetTeamsFromOrganization.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/GetTeamsFromOrganization.java
@@ -14,6 +14,6 @@ public class GetTeamsFromOrganization {
 
     @Transactional
     public List<Team> execute(Organization org) {
-        return org.getTeams();
+        return org.getTeams().stream().toList();
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Organization.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Organization.java
@@ -2,6 +2,7 @@ package io.pakland.mdas.githubstats.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -39,6 +40,10 @@ public class Organization {
 
         teams.add(team);
         team.setOrganization(this);
+    }
+
+    public List<Team> getTeams() {
+        return teams.stream().toList();
     }
 
     @Override

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Organization.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Organization.java
@@ -1,12 +1,11 @@
 package io.pakland.mdas.githubstats.domain;
 
-import javax.persistence.*;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import lombok.*;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -15,49 +14,49 @@ import java.util.List;
 @Builder
 @Table(name = "organization")
 public class Organization {
-  @Id
-  @Column(updatable = false, nullable = false)
-  @JsonProperty("id")
-  private Integer id;
 
-  @Column
-  @JsonProperty("login")
-  private String login;
+    @Id
+    @Column(updatable = false, nullable = false)
+    @JsonProperty("id")
+    @NotNull
+    private Integer id;
 
-  @OneToMany(
-    mappedBy = "organization",
-    cascade = CascadeType.ALL,
-    orphanRemoval = true
-  )
-  private List<Team> teams = new ArrayList<>();
+    @Column
+    @JsonProperty("login")
+    private String login;
 
-  public void addTeam(Team team) {
-    if (teams == null) {
-      teams = new ArrayList<>();
+    @OneToMany(
+        mappedBy = "organization",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true
+    )
+    private Set<Team> teams = new HashSet<>();
+
+    public void addTeam(Team team) {
+        if (teams == null) {
+            teams = new HashSet<>();
+        }
+
+        teams.add(team);
+        team.setOrganization(this);
     }
 
-    if (!teams.contains(team)) {
-      teams.add(team);
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Organization that = (Organization) o;
+
+        return id.equals(that.id);
     }
-    team.setOrganization(this);
-  }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    @Override
+    public int hashCode() {
+        return id.hashCode();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    Organization that = (Organization) o;
-
-    return id.equals(that.id);
-  }
-
-  @Override
-  public int hashCode() {
-    return id.hashCode();
-  }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Organization.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Organization.java
@@ -3,10 +3,7 @@ package io.pakland.mdas.githubstats.domain;
 import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@Builder
 @Table(name = "organization")
 public class Organization {
   @Id
@@ -32,4 +30,34 @@ public class Organization {
     orphanRemoval = true
   )
   private List<Team> teams = new ArrayList<>();
+
+  public void addTeam(Team team) {
+    if (teams == null) {
+      teams = new ArrayList<>();
+    }
+
+    if (!teams.contains(team)) {
+      teams.add(team);
+    }
+    team.setOrganization(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Organization that = (Organization) o;
+
+    return id.equals(that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return id.hashCode();
+  }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Repository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Repository.java
@@ -17,6 +17,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@Builder
 @Table(name = "repository")
 public class Repository {
 
@@ -45,5 +46,24 @@ public class Repository {
   @JsonProperty("owner")
   private void unpackNameFromNestedObject(Map<String, String> owner) {
     this.ownerLogin = owner.get("login");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Repository that = (Repository) o;
+
+    return id.equals(that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return id.hashCode();
   }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
@@ -1,9 +1,7 @@
 package io.pakland.mdas.githubstats.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -13,6 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@Builder
 @Table(name = "team")
 public class Team {
 
@@ -41,4 +40,15 @@ public class Team {
     orphanRemoval = true
   )
   private List<Repository> repositories = new ArrayList<>();
+
+  public void addRepository(Repository repository) {
+    if (repositories == null) {
+      repositories = new ArrayList<>();
+    }
+
+    if (!repositories.contains(repository)) {
+      repositories.add(repository);
+    }
+    repository.setTeam(this);
+  }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
@@ -1,11 +1,9 @@
 package io.pakland.mdas.githubstats.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.*;
-
+import java.util.*;
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
+import lombok.*;
 
 @Data
 @NoArgsConstructor
@@ -15,59 +13,57 @@ import java.util.List;
 @Table(name = "team")
 public class Team {
 
-  @Id
-  @Column(updatable = false, nullable = false)
-  @JsonProperty("id")
-  private Integer id;
+    @Id
+    @Column(updatable = false, nullable = false)
+    @JsonProperty("id")
+    private Integer id;
 
-  @Column(name = "slug")
-  @JsonProperty("slug")
-  private String slug;
+    @Column(name = "slug")
+    @JsonProperty("slug")
+    private String slug;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  private Organization organization;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Organization organization;
 
-  @OneToMany(
-    mappedBy = "team",
-    cascade = CascadeType.ALL,
-    orphanRemoval = true
-  )
-  private List<User> users = new ArrayList<>();
+    @OneToMany(
+        mappedBy = "team",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true
+    )
+    private List<User> users = new ArrayList<>();
 
-  @OneToMany(
-    mappedBy = "team",
-    cascade = CascadeType.ALL,
-    orphanRemoval = true
-  )
-  private List<Repository> repositories = new ArrayList<>();
+    @OneToMany(
+        mappedBy = "team",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true
+    )
+    private Set<Repository> repositories = new HashSet<>();
 
-  public void addRepository(Repository repository) {
-    if (repositories == null) {
-      repositories = new ArrayList<>();
+    public void addRepository(Repository repository) {
+        if (repositories == null) {
+            repositories = new HashSet<>();
+        }
+
+        repositories.add(repository);
+        repository.setTeam(this);
     }
 
-    if (!repositories.contains(repository)) {
-      repositories.add(repository);
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Team team = (Team) o;
+
+        return id.equals(team.id);
     }
-    repository.setTeam(this);
-  }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+    @Override
+    public int hashCode() {
+        return id.hashCode();
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    Team team = (Team) o;
-
-    return id.equals(team.id);
-  }
-
-  @Override
-  public int hashCode() {
-    return id.hashCode();
-  }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
@@ -51,4 +51,23 @@ public class Team {
     }
     repository.setTeam(this);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Team team = (Team) o;
+
+    return id.equals(team.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return id.hashCode();
+  }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
@@ -48,6 +48,10 @@ public class Team {
         repository.setTeam(this);
     }
 
+    public List<Repository> getRepositories() {
+        return repositories.stream().toList();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/controller/UserOptionController.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/controller/UserOptionController.java
@@ -54,7 +54,6 @@ public class UserOptionController {
 
                 for (Team team : teamList) {
                     // Fetch the members of each team.
-                    logger.info(organization.getLogin());
                     List<User> userList = new FetchUsersFromTeam(userExternalRepository)
                             .execute(organization.getLogin(), team.getSlug());
                     // Fetch the repositories for each team.
@@ -62,6 +61,7 @@ public class UserOptionController {
                             .execute(organization.getLogin(), team.getSlug());
 
                     for (Repository repository : repositoryList) {
+                        team.addRepository(repository);
                         // Fetch pull requests from each team.
                         List<PullRequest> pullRequestList = new FetchPullRequestsFromRepository(pullRequestExternalRepository)
                                 .execute(repository.getOwnerLogin(), repository.getName());
@@ -77,7 +77,6 @@ public class UserOptionController {
                     }
 
                     team.setUsers(userList);
-                    team.setRepositories(repositoryList);
                 }
 
                 organization.setTeams(teamList);

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/controller/UserOptionController.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/controller/UserOptionController.java
@@ -53,6 +53,7 @@ public class UserOptionController {
                         .execute(organization.getLogin());
 
                 for (Team team : teamList) {
+                    organization.addTeam(team);
                     // Fetch the members of each team.
                     List<User> userList = new FetchUsersFromTeam(userExternalRepository)
                             .execute(organization.getLogin(), team.getSlug());
@@ -78,8 +79,6 @@ public class UserOptionController {
 
                     team.setUsers(userList);
                 }
-
-                organization.setTeams(teamList);
             }
         } catch (HttpException e) {
             throw new RuntimeException(e);

--- a/src/test/java/io/pakland/mdas/githubstats/domain/OrganizationTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/OrganizationTest.java
@@ -1,0 +1,36 @@
+package io.pakland.mdas.githubstats.domain;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class OrganizationTest {
+
+    @Test
+    public void shouldAddTheTeamToTheOrganization_andSetTheTeamOrganization() {
+        Organization organization = Organization.builder().id(1).login("github-stats").build();
+        Team team = Team.builder().id(1).slug("gs-developers").build();
+        
+        assertNull(team.getOrganization());
+        organization.addTeam(team);
+
+        assertEquals(organization.getTeams().size(), 1);
+        assertEquals(team.getOrganization(), organization);
+    }
+
+    @Test
+    public void shouldNotAddTheTeam_whenTheTeamIsAlreadyContained() {
+        Organization organization = Organization.builder().id(1).login("github-stats").build();
+        Team team = Team.builder().id(1).slug("gs-developers").build();
+        organization.setTeams(Collections.singletonList(team));
+
+        assertNull(team.getOrganization());
+        assertEquals(organization.getTeams().size(), 1);
+        organization.addTeam(team);
+
+        assertEquals(organization.getTeams().size(), 1);
+        assertEquals(team.getOrganization(), organization);
+    }
+
+}

--- a/src/test/java/io/pakland/mdas/githubstats/domain/OrganizationTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/OrganizationTest.java
@@ -11,7 +11,7 @@ public class OrganizationTest {
     public void shouldAddTheTeamToTheOrganization_andSetTheTeamOrganization() {
         Organization organization = Organization.builder().id(1).login("github-stats").build();
         Team team = Team.builder().id(1).slug("gs-developers").build();
-        
+
         assertNull(team.getOrganization());
         organization.addTeam(team);
 
@@ -23,7 +23,7 @@ public class OrganizationTest {
     public void shouldNotAddTheTeam_whenTheTeamIsAlreadyContained() {
         Organization organization = Organization.builder().id(1).login("github-stats").build();
         Team team = Team.builder().id(1).slug("gs-developers").build();
-        organization.setTeams(Collections.singletonList(team));
+        organization.setTeams(Collections.singleton(team));
 
         assertNull(team.getOrganization());
         assertEquals(organization.getTeams().size(), 1);

--- a/src/test/java/io/pakland/mdas/githubstats/domain/OrganizationTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/OrganizationTest.java
@@ -1,8 +1,11 @@
 package io.pakland.mdas.githubstats.domain;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collections;
+import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 public class OrganizationTest {
@@ -23,7 +26,7 @@ public class OrganizationTest {
     public void shouldNotAddTheTeam_whenTheTeamIsAlreadyContained() {
         Organization organization = Organization.builder().id(1).login("github-stats").build();
         Team team = Team.builder().id(1).slug("gs-developers").build();
-        organization.setTeams(Collections.singleton(team));
+        organization.setTeams(new HashSet<>(Collections.singletonList(team)));
 
         assertNull(team.getOrganization());
         assertEquals(organization.getTeams().size(), 1);
@@ -31,6 +34,16 @@ public class OrganizationTest {
 
         assertEquals(organization.getTeams().size(), 1);
         assertEquals(team.getOrganization(), organization);
+    }
+
+    @Test
+    public void shouldCheckForEqualOrganizations() {
+        Organization original = Organization.builder().id(1).build();
+        Organization equal = Organization.builder().id(1).build();
+        Organization notEqual = Organization.builder().id(2).build();
+
+        assertEquals(original, equal);
+        assertNotEquals(original, notEqual);
     }
 
 }

--- a/src/test/java/io/pakland/mdas/githubstats/domain/TeamTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/TeamTest.java
@@ -1,0 +1,36 @@
+package io.pakland.mdas.githubstats.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class TeamTest {
+
+    @Test
+    public void shouldAddTheRepository_andAssignTheTeamToTheRepository() {
+        Team team = Team.builder().id(1).slug("gs-developers").build();
+        Repository repository = Repository.builder().id(1).name("github-stats").build();
+
+        assertNull(repository.getTeam());
+        team.addRepository(repository);
+
+        assertEquals(repository.getTeam(), team);
+        assertEquals(1, team.getRepositories().size());
+    }
+
+    @Test
+    public void shouldNotAddTheRepository_whenTheTeamIsAlreadyContained() {
+        Team team = Team.builder().id(1).slug("gs-developers").build();
+        Repository repository = Repository.builder().id(1).name("github-stats").build();
+        team.setRepositories(Collections.singletonList(repository));
+
+        assertNull(repository.getTeam());
+        team.addRepository(repository);
+
+        assertEquals(repository.getTeam(), team);
+        assertEquals(1, team.getRepositories().size());
+    }
+
+}

--- a/src/test/java/io/pakland/mdas/githubstats/domain/TeamTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/TeamTest.java
@@ -24,7 +24,7 @@ public class TeamTest {
     public void shouldNotAddTheRepository_whenTheRepositoryIsAlreadyContained() {
         Team team = Team.builder().id(1).slug("gs-developers").build();
         Repository repository = Repository.builder().id(1).name("github-stats").build();
-        team.setRepositories(Collections.singletonList(repository));
+        team.setRepositories(Collections.singleton(repository));
 
         assertNull(repository.getTeam());
         assertEquals(1, team.getRepositories().size());

--- a/src/test/java/io/pakland/mdas/githubstats/domain/TeamTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/TeamTest.java
@@ -21,12 +21,13 @@ public class TeamTest {
     }
 
     @Test
-    public void shouldNotAddTheRepository_whenTheTeamIsAlreadyContained() {
+    public void shouldNotAddTheRepository_whenTheRepositoryIsAlreadyContained() {
         Team team = Team.builder().id(1).slug("gs-developers").build();
         Repository repository = Repository.builder().id(1).name("github-stats").build();
         team.setRepositories(Collections.singletonList(repository));
 
         assertNull(repository.getTeam());
+        assertEquals(1, team.getRepositories().size());
         team.addRepository(repository);
 
         assertEquals(repository.getTeam(), team);

--- a/src/test/java/io/pakland/mdas/githubstats/domain/TeamTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/TeamTest.java
@@ -1,9 +1,11 @@
 package io.pakland.mdas.githubstats.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collections;
+import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
 public class TeamTest {
@@ -24,7 +26,7 @@ public class TeamTest {
     public void shouldNotAddTheRepository_whenTheRepositoryIsAlreadyContained() {
         Team team = Team.builder().id(1).slug("gs-developers").build();
         Repository repository = Repository.builder().id(1).name("github-stats").build();
-        team.setRepositories(Collections.singleton(repository));
+        team.setRepositories(new HashSet<>(Collections.singletonList(repository)));
 
         assertNull(repository.getTeam());
         assertEquals(1, team.getRepositories().size());
@@ -32,6 +34,16 @@ public class TeamTest {
 
         assertEquals(repository.getTeam(), team);
         assertEquals(1, team.getRepositories().size());
+    }
+
+    @Test
+    public void shouldCheckForEqualTeams() {
+        Team original = Team.builder().id(1).build();
+        Team equal = Team.builder().id(1).build();
+        Team notEqual = Team.builder().id(2).build();
+
+        assertEquals(original, equal);
+        assertNotEquals(original, notEqual);
     }
 
 }

--- a/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/OrganizationGitHubRepositoryTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/OrganizationGitHubRepositoryTest.java
@@ -1,44 +1,41 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import io.pakland.mdas.githubstats.domain.Organization;
-import io.pakland.mdas.githubstats.domain.Team;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OrganizationGitHubRepositoryTest {
 
+    private final Integer organizationId = 119930124;
     private MockWebServer mockWebServer;
     private OrganizationGitHubRepository organizationGithubRepository;
     private String availableOrganizationsListResponse;
-
-    private final Integer organizationId = 119930124;
-    private final Integer teamId = 7098104;
 
     @BeforeAll
     void setup() throws IOException {
         this.mockWebServer = new MockWebServer();
         this.mockWebServer.start();
-        WebClientConfiguration webClientConfiguration = new WebClientConfiguration(mockWebServer.url("/").toString(), "test-api-key");
-        this.organizationGithubRepository = new OrganizationGitHubRepository(webClientConfiguration);
-        this.availableOrganizationsListResponse = new String(Files.readAllBytes(Paths.get("src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/responses/AvailableOrganizations.json")));
+        WebClientConfiguration webClientConfiguration = new WebClientConfiguration(
+            mockWebServer.url("/").toString(), "test-api-key");
+        this.organizationGithubRepository = new OrganizationGitHubRepository(
+            webClientConfiguration);
+        this.availableOrganizationsListResponse = new String(Files.readAllBytes(Paths.get(
+            "src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/responses/AvailableOrganizations.json")));
     }
 
     @AfterAll
@@ -47,10 +44,11 @@ class OrganizationGitHubRepositoryTest {
     }
 
     @Test
-    void givenValidUserOrganizationsRequest_shouldCallUserOrganizationsEndpoint() throws InterruptedException, HttpException {
+    void givenValidUserOrganizationsRequest_shouldCallUserOrganizationsEndpoint()
+        throws InterruptedException, HttpException {
         MockResponse mockResponse = new MockResponse()
-                .setBody(this.availableOrganizationsListResponse)
-                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+            .setBody(this.availableOrganizationsListResponse)
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         mockWebServer.enqueue(mockResponse);
 
         organizationGithubRepository.fetchAvailableOrganizations();
@@ -63,13 +61,13 @@ class OrganizationGitHubRepositoryTest {
     void givenValidGithubAPIKey_shouldReturnAPIKeyUserOrganizations() throws HttpException {
 
         MockResponse mockResponse = new MockResponse()
-                .setBody(this.availableOrganizationsListResponse)
-                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+            .setBody(this.availableOrganizationsListResponse)
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         mockWebServer.enqueue(mockResponse);
 
         List<Organization> response = organizationGithubRepository.fetchAvailableOrganizations();
         List<Organization> expected = new ArrayList<>();
-        expected.add(new Organization(this.organizationId, "github-stats-22", new ArrayList<Team>()));
+        expected.add(new Organization(this.organizationId, "github-stats-22", new HashSet<>()));
 
         assertArrayEquals(response.toArray(), expected.toArray());
     }

--- a/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepositoryTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepositoryTest.java
@@ -1,44 +1,41 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
-import io.pakland.mdas.githubstats.application.exceptions.HttpException;
-import io.pakland.mdas.githubstats.domain.Repository;
-import io.pakland.mdas.githubstats.domain.Team;
-import io.pakland.mdas.githubstats.domain.User;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.domain.Team;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TeamGitHubRepositoryTest {
-    private MockWebServer mockWebServer;
-    private TeamGitHubRepository teamGitHubRepository;
-    private String organizationTeamsListResponse;
 
     private final String organizationName = "github-stats-22";
     private final String teamName = "gs-developers";
+    private MockWebServer mockWebServer;
+    private TeamGitHubRepository teamGitHubRepository;
+    private String organizationTeamsListResponse;
 
     @BeforeAll
     void setup() throws IOException {
         this.mockWebServer = new MockWebServer();
         this.mockWebServer.start();
-        WebClientConfiguration webClientConfiguration = new WebClientConfiguration(mockWebServer.url("/").toString(), "test-api-key");
+        WebClientConfiguration webClientConfiguration = new WebClientConfiguration(
+            mockWebServer.url("/").toString(), "test-api-key");
         this.teamGitHubRepository = new TeamGitHubRepository(webClientConfiguration);
-        this.organizationTeamsListResponse = new String(Files.readAllBytes(Paths.get("src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/responses/OrganizationTeams.json")));
+        this.organizationTeamsListResponse = new String(Files.readAllBytes(Paths.get(
+            "src/test/java/io/pakland/mdas/githubstats/infrastructure/github/repository/responses/OrganizationTeams.json")));
     }
 
     @AfterAll
@@ -47,10 +44,11 @@ class TeamGitHubRepositoryTest {
     }
 
     @Test
-    void givenValidTeamMembersRequest_shouldCallTeamMembersEndpoint() throws InterruptedException, HttpException {
+    void givenValidTeamMembersRequest_shouldCallTeamMembersEndpoint()
+        throws InterruptedException, HttpException {
         MockResponse mockResponse = new MockResponse()
-                .setBody(this.organizationTeamsListResponse)
-                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+            .setBody(this.organizationTeamsListResponse)
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         mockWebServer.enqueue(mockResponse);
 
         teamGitHubRepository.fetchTeamsFromOrganization(this.organizationName);
@@ -62,13 +60,15 @@ class TeamGitHubRepositoryTest {
     @Test
     void givenValidTeamName_shouldReturnTeamMembers() throws HttpException {
         MockResponse mockResponse = new MockResponse()
-                .setBody(this.organizationTeamsListResponse)
-                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+            .setBody(this.organizationTeamsListResponse)
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         mockWebServer.enqueue(mockResponse);
 
-        List<Team> response = teamGitHubRepository.fetchTeamsFromOrganization(this.organizationName);
+        List<Team> response = teamGitHubRepository.fetchTeamsFromOrganization(
+            this.organizationName);
         List<Team> expected = new ArrayList<>();
-        expected.add(0, new Team(7098104, "gs-developers", null, new ArrayList<User>(), new ArrayList<Repository>()));
+        expected.add(0,
+            new Team(7098104, teamName, null, new ArrayList<>(), new HashSet<>()));
 
         assertEquals(1, response.size());
         assertArrayEquals(response.toArray(), expected.toArray());


### PR DESCRIPTION
### Description

- Fixed the `Team-Repository` association in the `UserOptionController`.
- Fixed the `Organization-Team` association in the `UserOptionController`.

#### Decisions taken

I opted to override the `hashCode` and `equals` methods using only the `id`
field. The reason is because if done properly, we should not have duplicated
entities and each entity is uniquely identified by the `id` field.

Closes #92

<!-- 
REMINDER:

- Set the name of the pr as:
  <type>: <meaningful-title>
- Add all the team as reviewers, so that we are all notified for review
- Add the corresponding labels:
  - "status: code review": if the pr is ready for review
  - "status: wip": if you are still working on it (mark the PR as a draft)
  - "type: <type>": set it to the corresponding type
- Add the PR to the project, move it to the in progress/in review column
- Add it to the corresponding milestone
-->
