### PR TITLE
feat: request full commit data from pr list

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/domain/Commit.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Commit.java
@@ -1,12 +1,13 @@
 package io.pakland.mdas.githubstats.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import javax.persistence.*;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 
@@ -31,9 +32,19 @@ public class Commit {
     @ManyToOne(fetch = FetchType.LAZY)
     private PullRequest pullRequest;
 
+    private int additions;
+
+    private int deletions;
+
     @JsonProperty("commit")
     private void unpackDateFromNestedObject(Map<String, Object> commitJson) {
         Map<String, Object> committer = (Map<String, Object>)commitJson.get("committer");
         this.date = Date.from(Instant.parse(committer.get("date").toString()));
+    }
+
+    @JsonProperty("stats")
+    private void setAdditionDeletionsLines(Map<String, Object> stats) {
+        additions = Integer.parseInt(stats.get("additions").toString());
+        deletions = Integer.parseInt(stats.get("deletions").toString());
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/CommitAggregation.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/CommitAggregation.java
@@ -6,14 +6,24 @@ public class CommitAggregation {
 
     private int numCommits;
 
+    private int linesAdded;
+
+    private int linesRemoved;
+
     public static CommitAggregation aggregate(List<Commit> commits) {
         CommitAggregation commitAggregation = new CommitAggregation();
         commitAggregation.numCommits = (int) commits.stream().distinct().count();
+        commitAggregation.linesAdded = commits.stream().mapToInt(Commit::getAdditions).sum();
+        commitAggregation.linesRemoved = commits.stream().mapToInt(Commit::getDeletions).sum();
         return commitAggregation;
     }
 
     public int getNumCommits() {
         return numCommits;
     }
+
+    public int getLinesAdded() { return linesAdded; }
+
+    public int getLinesRemoved() { return linesRemoved; }
 
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommitGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommitGitHubRepository.java
@@ -1,13 +1,23 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import io.pakland.mdas.githubstats.domain.Commit;
+import io.pakland.mdas.githubstats.domain.PullRequest;
 import io.pakland.mdas.githubstats.domain.repository.CommitExternalRepository;
+import lombok.Data;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import java.util.ArrayList;
 import java.util.List;
+
+@Data
+class CommitSha {
+    @JsonProperty("sha")
+    private String sha;
+}
 
 public class CommitGitHubRepository implements CommitExternalRepository {
     private final WebClientConfiguration webClientConfiguration;
@@ -21,13 +31,31 @@ public class CommitGitHubRepository implements CommitExternalRepository {
     public List<Commit> fetchCommitsFromPullRequest(FetchCommitsFromPullRequestRequest request) throws HttpException {
 
         try {
-            return this.webClientConfiguration.getWebClient().get()
+
+            List<CommitSha> commitsSha = this.webClientConfiguration.getWebClient().get()
                     .uri(String.format("/repos/%s/%s/pulls/%s/commits?%s", request.getRepositoryOwner(),
                             request.getRepositoryName(), request.getPullRequestNumber(), getRequestParams(request)))
                     .retrieve()
-                    .bodyToFlux(Commit.class)
+                    .bodyToFlux(CommitSha.class)
                     .collectList()
                     .block();
+
+            List<Commit> commits = new ArrayList<>();
+            if (commitsSha != null) {
+                for (CommitSha commitSha : commitsSha) {
+                    commits.add(
+                            (Commit) this.webClientConfiguration.getWebClient().get()
+                                    .uri(String.format("/repos/%s/%s/commits/%s", request.getRepositoryOwner(),
+                                            request.getRepositoryName(), commitSha.getSha()))
+                                    .retrieve()
+                                    .bodyToMono(Commit.class)
+                                    .block()
+                    );
+                }
+            }
+
+            return commits;
+
         } catch (WebClientResponseException ex) {
             logger.error(ex.toString());
             throw new HttpException(ex.getRawStatusCode(), ex.getMessage());

--- a/src/main/resources/db/changelog/changes/000_initial_schema.yaml
+++ b/src/main/resources/db/changelog/changes/000_initial_schema.yaml
@@ -45,6 +45,12 @@ databaseChangeLog:
               - column:
                   name: user_id
                   type: INT
+              - column:
+                  name: additions
+                  type: INT
+              - column:
+                  name: deletions
+                  type: INT
             tableName: commit
   - changeSet:
       id: 1669767244074-3


### PR DESCRIPTION
As @manerow noted on WhatsApp, the lines added and deleted from a commit didn't come in the JSON when you retrieve the PR commit list. It seems that is needed to retrieve every commit individually by its SHA code, and get the additions and deletions from the stats section.

This PR is blocked by #108, because it needs its code to compile.