### PR TITLE
fix: remove `JsonProperty` from `User` entity

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/UserDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/UserDTO.java
@@ -1,0 +1,6 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+public interface UserDTO {
+    Integer getId();
+    String getLogin();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/external/FetchUsersFromTeam.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/external/FetchUsersFromTeam.java
@@ -7,7 +7,7 @@ import io.pakland.mdas.githubstats.domain.repository.UserExternalRepository;
 import java.util.List;
 
 public class FetchUsersFromTeam {
-    private UserExternalRepository userExternalRepository;
+    private final UserExternalRepository userExternalRepository;
 
 
     public FetchUsersFromTeam(UserExternalRepository userExternalRepository) {

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/UserMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/UserMapper.java
@@ -2,9 +2,16 @@ package io.pakland.mdas.githubstats.application.mappers;
 
 import io.pakland.mdas.githubstats.application.dto.UserDTO;
 import io.pakland.mdas.githubstats.domain.entity.User;
+import java.util.ArrayList;
 
 public class UserMapper {
     public static User dtoToEntity(UserDTO dto) {
-        return User.builder().id(dto.getId()).login(dto.getLogin()).build();
+        return User.builder()
+            .id(dto.getId())
+            .login(dto.getLogin())
+            .userReviews(new ArrayList<>())
+            .commits(new ArrayList<>())
+            .pullRequests(new ArrayList<>())
+            .build();
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/UserMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/UserMapper.java
@@ -1,0 +1,10 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import io.pakland.mdas.githubstats.application.dto.UserDTO;
+import io.pakland.mdas.githubstats.domain.entity.User;
+
+public class UserMapper {
+    public static User dtoToEntity(UserDTO dto) {
+        return User.builder().id(dto.getId()).login(dto.getLogin()).build();
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/User.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/User.java
@@ -1,9 +1,7 @@
 package io.pakland.mdas.githubstats.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -12,6 +10,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "user")
 public class User {

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/User.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/User.java
@@ -18,11 +18,9 @@ public class User {
 
   @Id
   @Column(updatable = false, nullable = false)
-  @JsonProperty("id")
   private Integer id;
 
   @Column(name = "login")
-  @JsonProperty("login")
   private String login;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubUserDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubUserDTO.java
@@ -1,11 +1,20 @@
 package io.pakland.mdas.githubstats.infrastructure.github.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.UserDTO;
 
-public class GitHubUserDTO {
+public class GitHubUserDTO implements UserDTO {
     @JsonProperty("id")
     private Integer id;
 
     @JsonProperty("login")
     private String login;
+
+    public Integer getId() {
+        return this.id;
+    }
+
+    public String getLogin() {
+        return this.login;
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubUserDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubUserDTO.java
@@ -1,0 +1,11 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitHubUserDTO {
+    @JsonProperty("id")
+    private Integer id;
+
+    @JsonProperty("login")
+    private String login;
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/UserGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/UserGitHubRepository.java
@@ -1,14 +1,15 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.application.mappers.UserMapper;
 import io.pakland.mdas.githubstats.domain.entity.User;
 import io.pakland.mdas.githubstats.domain.repository.UserExternalRepository;
+import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubUserDTO;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-
-import java.util.List;
 
 @Repository
 public class UserGitHubRepository implements UserExternalRepository {
@@ -21,15 +22,17 @@ public class UserGitHubRepository implements UserExternalRepository {
     }
 
     @Override
-    public List<User> fetchUsersFromTeam(String organizationName, String teamName) throws HttpException {
+    public List<User> fetchUsersFromTeam(String organizationName, String teamName)
+        throws HttpException {
         try {
             return this.webClientConfiguration.getWebClient().get()
-                    .uri(String.format("/orgs/%s/teams/%s/members", organizationName, teamName))
-                    .retrieve()
-                    .bodyToFlux(User.class)
-                    .collectList()
-                    .block();
-        }  catch (WebClientResponseException ex) {
+                .uri(String.format("/orgs/%s/teams/%s/members", organizationName, teamName))
+                .retrieve()
+                .bodyToFlux(GitHubUserDTO.class)
+                .map(UserMapper::dtoToEntity)
+                .collectList()
+                .block();
+        } catch (WebClientResponseException ex) {
             logger.error(ex.toString());
             throw new HttpException(ex.getRawStatusCode(), ex.getMessage());
         }

--- a/src/test/java/io/pakland/mdas/githubstats/application/mappers/UserMapperTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/mappers/UserMapperTest.java
@@ -1,0 +1,24 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.pakland.mdas.githubstats.application.dto.UserDTO;
+import io.pakland.mdas.githubstats.domain.entity.User;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class UserMapperTest {
+    @Test
+    public void shouldConvertDtoToEntity() {
+        UserDTO dto = Mockito.mock(UserDTO.class);
+        Mockito.when(dto.getId()).thenReturn(1);
+        Mockito.when(dto.getLogin()).thenReturn("github-stats");
+
+        User entity = UserMapper.dtoToEntity(dto);
+
+        assertEquals(1, (int) entity.getId());
+        assertEquals("github-stats", entity.getLogin());
+    }
+
+}


### PR DESCRIPTION
### Description

- Created the `GitHubUserDTO` that allows us to parse the response from the GitHub API.
- Added the `UserMapper` that allows us to service-agnostically convert the `DTO` to an `Entity`.
- Added the `UserMapper` to the GitHub repository that was using it.
