### PR TITLE
fix: remove @JsonProperty from Comment Entity

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/CommentDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/CommentDTO.java
@@ -1,0 +1,7 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+public interface CommentDTO {
+    Integer getId();
+
+    Integer getLength();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/CommentMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/CommentMapper.java
@@ -1,0 +1,13 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import io.pakland.mdas.githubstats.application.dto.CommentDTO;
+import io.pakland.mdas.githubstats.domain.entity.Comment;
+
+public class CommentMapper {
+    public static Comment dtoToEntity(CommentDTO dto) {
+        return Comment.builder()
+                .id(dto.getId())
+                .length(dto.getLength())
+                .build();
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/Comment.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/Comment.java
@@ -1,37 +1,26 @@
 package io.pakland.mdas.githubstats.domain.entity;
 
-import javax.persistence.*;
-
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
+
+import javax.persistence.*;
 
 @Data
 @NoArgsConstructor
-@ToString
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "comment")
 public class Comment {
 
-  @Id
-  @Column(updatable = false, nullable = false)
-  private Integer id;
+    @Id
+    @Column(updatable = false, nullable = false)
+    private Integer id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  private UserReview userReview;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private UserReview userReview;
 
-  private int length;
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof Comment )) return false;
-    return id != null && id.equals(((Comment) o).getId());
-  }
-
-  @Override
-  public int hashCode() {
-    return getClass().hashCode();
-  }
-
+    private int length;
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommentDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommentDTO.java
@@ -1,0 +1,28 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.CommentDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitHubCommentDTO implements CommentDTO {
+    @JsonProperty("id")
+    private Integer id;
+
+    @JsonProperty("body")
+    private String body;
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+
+    @Override
+    public Integer getLength() {
+        return this.body.length();
+    }
+}

--- a/src/test/java/io/pakland/mdas/githubstats/application/mappers/CommentMapperTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/mappers/CommentMapperTest.java
@@ -1,0 +1,20 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import io.pakland.mdas.githubstats.application.dto.CommentDTO;
+import io.pakland.mdas.githubstats.domain.entity.Comment;
+import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubCommentDTO;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CommentMapperTest {
+
+    @Test
+    public void shouldConvertDTOToEntity() {
+        CommentDTO commentDTO = new GitHubCommentDTO(1, "This is a test comment");
+        Comment commentEntity = CommentMapper.dtoToEntity(commentDTO);
+
+        assertEquals(1, (int) commentEntity.getId());
+        assertEquals(22, commentEntity.getLength());
+    }
+}


### PR DESCRIPTION
- Created the GitHubCommentDTO that allows us to parse the response from the GitHub API.
- Added the CommentMapper that allows us to service-agnostically convert the DTO to an Entity.
- Added the CommentMapper to the GitHub repository that was using it.

Closes #121