### PR TITLE
fix: remove `JsonProperty` from `Team` entity

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/TeamDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/TeamDTO.java
@@ -1,0 +1,6 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+public interface TeamDTO {
+    Integer getId();
+    String getSlug();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/TeamMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/TeamMapper.java
@@ -1,0 +1,10 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import io.pakland.mdas.githubstats.application.dto.TeamDTO;
+import io.pakland.mdas.githubstats.domain.entity.Team;
+
+public class TeamMapper {
+    public static Team dtoToEntity(TeamDTO dto) {
+        return Team.builder().id(dto.getId()).slug(dto.getSlug()).build();
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/Team.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/Team.java
@@ -15,11 +15,9 @@ public class Team {
 
     @Id
     @Column(updatable = false, nullable = false)
-    @JsonProperty("id")
     private Integer id;
 
     @Column(name = "slug")
-    @JsonProperty("slug")
     private String slug;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubTeamDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubTeamDTO.java
@@ -1,11 +1,22 @@
 package io.pakland.mdas.githubstats.infrastructure.github.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.TeamDTO;
 
-public class GitHubTeamDTO {
+public class GitHubTeamDTO implements TeamDTO {
     @JsonProperty("id")
     private Integer id;
 
     @JsonProperty("slug")
     private String slug;
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getSlug() {
+        return this.slug;
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubTeamDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubTeamDTO.java
@@ -1,0 +1,11 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitHubTeamDTO {
+    @JsonProperty("id")
+    private Integer id;
+
+    @JsonProperty("slug")
+    private String slug;
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepository.java
@@ -1,13 +1,14 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
+import io.pakland.mdas.githubstats.application.dto.TeamDTO;
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.application.mappers.TeamMapper;
 import io.pakland.mdas.githubstats.domain.entity.Team;
 import io.pakland.mdas.githubstats.domain.repository.TeamExternalRepository;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-
-import java.util.List;
 
 public class TeamGitHubRepository implements TeamExternalRepository {
 
@@ -22,12 +23,13 @@ public class TeamGitHubRepository implements TeamExternalRepository {
     public List<Team> fetchTeamsFromOrganization(String organizationName) throws HttpException {
         try {
             return this.webClientConfiguration.getWebClient().get()
-                    .uri(String.format("/orgs/%s/teams", organizationName))
-                    .retrieve()
-                    .bodyToFlux(Team.class)
-                    .collectList()
-                    .block();
-        }  catch (WebClientResponseException ex) {
+                .uri(String.format("/orgs/%s/teams", organizationName))
+                .retrieve()
+                .bodyToFlux(TeamDTO.class)
+                .map(TeamMapper::dtoToEntity)
+                .collectList()
+                .block();
+        } catch (WebClientResponseException ex) {
             logger.error(ex.toString());
             throw new HttpException(ex.getRawStatusCode(), ex.getMessage());
         }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepository.java
@@ -1,10 +1,10 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
-import io.pakland.mdas.githubstats.application.dto.TeamDTO;
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import io.pakland.mdas.githubstats.application.mappers.TeamMapper;
 import io.pakland.mdas.githubstats.domain.entity.Team;
 import io.pakland.mdas.githubstats.domain.repository.TeamExternalRepository;
+import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubTeamDTO;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +25,7 @@ public class TeamGitHubRepository implements TeamExternalRepository {
             return this.webClientConfiguration.getWebClient().get()
                 .uri(String.format("/orgs/%s/teams", organizationName))
                 .retrieve()
-                .bodyToFlux(TeamDTO.class)
+                .bodyToFlux(GitHubTeamDTO.class)
                 .map(TeamMapper::dtoToEntity)
                 .collectList()
                 .block();

--- a/src/test/java/io/pakland/mdas/githubstats/application/mappers/TeamMapperTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/mappers/TeamMapperTest.java
@@ -1,0 +1,23 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.pakland.mdas.githubstats.application.dto.TeamDTO;
+import io.pakland.mdas.githubstats.domain.entity.Team;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TeamMapperTest {
+
+    @Test
+    public void shouldConvertDtoToEntity() {
+        TeamDTO dto = Mockito.mock(TeamDTO.class);
+        Mockito.when(dto.getId()).thenReturn(1);
+        Mockito.when(dto.getSlug()).thenReturn("gs-internal");
+
+        Team entity = TeamMapper.dtoToEntity(dto);
+
+        assertEquals(1, (int) entity.getId());
+        assertEquals("gs-internal", entity.getSlug());
+    }
+}


### PR DESCRIPTION
### Description

- Created the `GitHubTeamDTO` that allows us to parse the response from the GitHub API.
- Added the `TeamMapper` that allows us to serice-agnostically convert the `DTO` to an `Entity`.
- Added the `TeamMapper` to the GitHub repository that required it.

Closes #135 

> I incorrectly named the branch...
