### PR TITLE
fix: remove `JsonProperty` from `PullRequest`

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestDTO.java
@@ -1,0 +1,9 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
+
+public interface PullRequestDTO {
+    Integer getId();
+    Integer getNumber();
+    PullRequestState getState();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/PullRequestMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/PullRequestMapper.java
@@ -1,0 +1,16 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import io.pakland.mdas.githubstats.application.dto.PullRequestDTO;
+import io.pakland.mdas.githubstats.domain.entity.PullRequest;
+
+public class PullRequestMapper {
+
+    public static PullRequest dtoToEntity(PullRequestDTO dto) {
+        return PullRequest.builder()
+            .id(dto.getId())
+            .number(dto.getNumber())
+            .state(dto.getState())
+            .build();
+    }
+
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequest.java
@@ -10,6 +10,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@Builder
 @Table(name = "pull_request")
 public class PullRequest {
 

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequest.java
@@ -1,16 +1,10 @@
 package io.pakland.mdas.githubstats.domain.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import lombok.ToString;
+import javax.persistence.*;
+import lombok.*;
 
 @Data
 @NoArgsConstructor
@@ -18,17 +12,15 @@ import lombok.ToString;
 @Entity
 @Table(name = "pull_request")
 public class PullRequest {
+
     @Id
     @Column(updatable = false, nullable = false)
-    @JsonProperty("id")
     private Integer id;
 
     @Column(name = "number")
-    @JsonProperty("number")
     private Integer number;
 
     @Column(name = "state")
-    @JsonProperty("state")
     private PullRequestState state;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -39,39 +31,39 @@ public class PullRequest {
     private User user;
 
     @OneToMany(
-            mappedBy = "pullRequest",
-            cascade = CascadeType.ALL,
-            orphanRemoval = true
+        mappedBy = "pullRequest",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true
     )
     private List<Commit> commits = new ArrayList<>();
 
     @OneToMany(
-            cascade = CascadeType.ALL,
-            mappedBy = "pullRequest",
-            orphanRemoval = true
+        cascade = CascadeType.ALL,
+        mappedBy = "pullRequest",
+        orphanRemoval = true
     )
     private List<UserReview> userReviews = new ArrayList<>();
 
     public List<Commit> getCommitsByUser(User user) {
-      return commits
-          .stream()
-          .filter(commit -> commit.getUser().equals(user))
-          .collect(Collectors.toList());
+        return commits
+            .stream()
+            .filter(commit -> commit.getUser().equals(user))
+            .collect(Collectors.toList());
     }
 
     public boolean isClosed() {
-      return state.equals(PullRequestState.CLOSED);
+        return state.equals(PullRequestState.CLOSED);
     }
 
     public boolean isCreatedByUser(User user) {
-      return this.user.equals(user);
+        return this.user.equals(user);
     }
 
     public List<UserReview> getReviewsFromUser(User user) {
-      return userReviews
-          .stream()
-          .filter(x -> x.getUser().equals(user))
-          .collect(Collectors.toList());
+        return userReviews
+            .stream()
+            .filter(x -> x.getUser().equals(user))
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
@@ -1,9 +1,10 @@
 package io.pakland.mdas.githubstats.infrastructure.github.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.PullRequestDTO;
 import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
 
-public class GitHubPullRequestDTO {
+public class GitHubPullRequestDTO implements PullRequestDTO {
 
     @JsonProperty("id")
     private Integer id;
@@ -13,5 +14,20 @@ public class GitHubPullRequestDTO {
 
     @JsonProperty("state")
     private PullRequestState state;
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+
+    @Override
+    public Integer getNumber() {
+        return this.number;
+    }
+
+    @Override
+    public PullRequestState getState() {
+        return this.state;
+    }
 
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
@@ -1,0 +1,17 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
+
+public class GitHubPullRequestDTO {
+
+    @JsonProperty("id")
+    private Integer id;
+
+    @JsonProperty("number")
+    private Integer number;
+
+    @JsonProperty("state")
+    private PullRequestState state;
+
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/PullRequestGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/PullRequestGitHubRepository.java
@@ -1,8 +1,10 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.application.mappers.PullRequestMapper;
 import io.pakland.mdas.githubstats.domain.entity.PullRequest;
 import io.pakland.mdas.githubstats.domain.repository.PullRequestExternalRepository;
+import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubPullRequestDTO;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +27,8 @@ public class PullRequestGitHubRepository implements PullRequestExternalRepositor
                 .uri(String.format("/repos/%s/%s/pulls?%s", request.getRepositoryOwner(),
                     request.getRepository(), getRequestParams(request)))
                 .retrieve()
-                .bodyToFlux(PullRequest.class)
+                .bodyToFlux(GitHubPullRequestDTO.class)
+                .map(PullRequestMapper::dtoToEntity)
                 .collectList()
                 .block();
         } catch (WebClientResponseException ex) {

--- a/src/test/java/io/pakland/mdas/githubstats/application/mappers/PullRequestMapperTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/mappers/PullRequestMapperTest.java
@@ -1,0 +1,27 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.pakland.mdas.githubstats.application.dto.PullRequestDTO;
+import io.pakland.mdas.githubstats.domain.entity.PullRequest;
+import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class PullRequestMapperTest {
+
+    @Test
+    public void shouldConvertDtoToEntity() {
+        PullRequestDTO dto = Mockito.mock(PullRequestDTO.class);
+        Mockito.when(dto.getId()).thenReturn(1);
+        Mockito.when(dto.getNumber()).thenReturn(1);
+        Mockito.when(dto.getState()).thenReturn(PullRequestState.ALL);
+
+        PullRequest entity = PullRequestMapper.dtoToEntity(dto);
+
+        assertEquals(1, entity.getId());
+        assertEquals(1, entity.getNumber());
+        assertEquals(PullRequestState.ALL, entity.getState());
+    }
+
+}


### PR DESCRIPTION
### Description

- Created the `GitHubPullRequestDTO` that allows us to parse the response from the GitHub API.
- Added the `PullRequestMapper` that allows us to serice-agnostically convert the DTO to an Entity.
- Added the `PullRequestMapper` to the GitHub repository that required it.

Closes #131

> This should be merged after #136.
