### PR TITLE
fix: remove `JsonProperty` from `PullRequestState` 

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestStateDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestStateDTO.java
@@ -1,0 +1,5 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+public interface PullRequestStateDTO {
+    String getValue();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestStateDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestStateDTO.java
@@ -1,5 +1,7 @@
 package io.pakland.mdas.githubstats.application.dto;
 
+import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
+
 public interface PullRequestStateDTO {
-    String getValue();
+    PullRequestState getValue();
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequestState.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequestState.java
@@ -3,21 +3,18 @@ package io.pakland.mdas.githubstats.domain.entity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum PullRequestState {
-    @JsonProperty("all")
     ALL {
         @Override
         public String toString() {
             return "all";
         }
     },
-    @JsonProperty("open")
     OPEN {
         @Override
         public String toString() {
             return "open";
         }
     },
-    @JsonProperty("closed")
     CLOSED {
         @Override
         public String toString() {

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
@@ -2,6 +2,7 @@ package io.pakland.mdas.githubstats.infrastructure.github.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.pakland.mdas.githubstats.application.dto.PullRequestDTO;
+import io.pakland.mdas.githubstats.application.dto.PullRequestStateDTO;
 import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
 
 public class GitHubPullRequestDTO implements PullRequestDTO {
@@ -13,7 +14,7 @@ public class GitHubPullRequestDTO implements PullRequestDTO {
     private Integer number;
 
     @JsonProperty("state")
-    private PullRequestState state;
+    private PullRequestStateDTO state;
 
     @Override
     public Integer getId() {
@@ -27,7 +28,7 @@ public class GitHubPullRequestDTO implements PullRequestDTO {
 
     @Override
     public PullRequestState getState() {
-        return this.state;
+        return this.state.getValue();
     }
 
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestStateDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestStateDTO.java
@@ -1,0 +1,20 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.PullRequestStateDTO;
+import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
+
+public class GitHubPullRequestStateDTO implements PullRequestStateDTO {
+
+    @JsonProperty("state")
+    private String value;
+
+    @Override
+    public PullRequestState getValue() {
+        return switch (this.value) {
+            case "closed" -> PullRequestState.CLOSED;
+            case "open" -> PullRequestState.OPEN;
+            default -> PullRequestState.ALL;
+        };
+    }
+}


### PR DESCRIPTION
### Description

- Created `GitHubPullRequestStateDTO` that allows us to parse the response from the GitHub API
- Use such DTO inside the `GitHubPullRequestDTO`

Closes #132 

> This should be merged afetr #137

