### PR TITLE
fix: remove `JsonPropert` from `Organization`

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/OrganizationDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/OrganizationDTO.java
@@ -1,0 +1,6 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+public interface OrganizationDTO {
+    Integer getId();
+    String getLogin();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestStateDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestStateDTO.java
@@ -1,0 +1,5 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+public interface PullRequestStateDTO {
+    String getValue();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestStateDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestStateDTO.java
@@ -1,5 +1,7 @@
 package io.pakland.mdas.githubstats.application.dto;
 
+import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
+
 public interface PullRequestStateDTO {
-    String getValue();
+    PullRequestState getValue();
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/OrganizationMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/OrganizationMapper.java
@@ -1,0 +1,11 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import io.pakland.mdas.githubstats.application.dto.OrganizationDTO;
+import io.pakland.mdas.githubstats.domain.entity.Organization;
+
+public class OrganizationMapper {
+
+    public static Organization dtoToEntity(OrganizationDTO dto) {
+        return Organization.builder().id(dto.getId()).login(dto.getLogin()).build();
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/Organization.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/Organization.java
@@ -18,12 +18,10 @@ public class Organization {
 
     @Id
     @Column(updatable = false, nullable = false)
-    @JsonProperty("id")
     @NotNull
     private Integer id;
 
     @Column
-    @JsonProperty("login")
     private String login;
 
     @OneToMany(

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequestState.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequestState.java
@@ -3,21 +3,18 @@ package io.pakland.mdas.githubstats.domain.entity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum PullRequestState {
-    @JsonProperty("all")
     ALL {
         @Override
         public String toString() {
             return "all";
         }
     },
-    @JsonProperty("open")
     OPEN {
         @Override
         public String toString() {
             return "open";
         }
     },
-    @JsonProperty("closed")
     CLOSED {
         @Override
         public String toString() {

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubOrganizationDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubOrganizationDTO.java
@@ -1,12 +1,23 @@
 package io.pakland.mdas.githubstats.infrastructure.github.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.OrganizationDTO;
 
-public class GitHubOrganizationDTO {
+public class GitHubOrganizationDTO implements OrganizationDTO {
 
     @JsonProperty("id")
     private Integer id;
 
     @JsonProperty("login")
     private String login;
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getLogin() {
+        return this.login;
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubOrganizationDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubOrganizationDTO.java
@@ -1,0 +1,12 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitHubOrganizationDTO {
+
+    @JsonProperty("id")
+    private Integer id;
+
+    @JsonProperty("login")
+    private String login;
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
@@ -2,6 +2,7 @@ package io.pakland.mdas.githubstats.infrastructure.github.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.pakland.mdas.githubstats.application.dto.PullRequestDTO;
+import io.pakland.mdas.githubstats.application.dto.PullRequestStateDTO;
 import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
 
 public class GitHubPullRequestDTO implements PullRequestDTO {
@@ -13,7 +14,7 @@ public class GitHubPullRequestDTO implements PullRequestDTO {
     private Integer number;
 
     @JsonProperty("state")
-    private PullRequestState state;
+    private PullRequestStateDTO state;
 
     @Override
     public Integer getId() {
@@ -27,7 +28,7 @@ public class GitHubPullRequestDTO implements PullRequestDTO {
 
     @Override
     public PullRequestState getState() {
-        return this.state;
+        return this.state.getValue();
     }
 
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestStateDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestStateDTO.java
@@ -1,0 +1,20 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.PullRequestStateDTO;
+import io.pakland.mdas.githubstats.domain.entity.PullRequestState;
+
+public class GitHubPullRequestStateDTO implements PullRequestStateDTO {
+
+    @JsonProperty("state")
+    private String value;
+
+    @Override
+    public PullRequestState getValue() {
+        return switch (this.value) {
+            case "closed" -> PullRequestState.CLOSED;
+            case "open" -> PullRequestState.OPEN;
+            default -> PullRequestState.ALL;
+        };
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/OrganizationGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/OrganizationGitHubRepository.java
@@ -1,13 +1,14 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.application.mappers.OrganizationMapper;
 import io.pakland.mdas.githubstats.domain.entity.Organization;
 import io.pakland.mdas.githubstats.domain.repository.OrganizationExternalRepository;
+import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubOrganizationDTO;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-
-import java.util.List;
 
 public class OrganizationGitHubRepository implements OrganizationExternalRepository {
 
@@ -22,11 +23,12 @@ public class OrganizationGitHubRepository implements OrganizationExternalReposit
     public List<Organization> fetchAvailableOrganizations() throws HttpException {
         try {
             return this.webClientConfiguration.getWebClient().get()
-                    .uri("/user/orgs")
-                    .retrieve()
-                    .bodyToFlux(Organization.class)
-                    .collectList()
-                    .block();
+                .uri("/user/orgs")
+                .retrieve()
+                .bodyToFlux(GitHubOrganizationDTO.class)
+                .map(OrganizationMapper::dtoToEntity)
+                .collectList()
+                .block();
         } catch (WebClientResponseException ex) {
             logger.error(ex.toString());
             throw new HttpException(ex.getRawStatusCode(), ex.getMessage());

--- a/src/test/java/io/pakland/mdas/githubstats/application/mappers/OrganizationMapperTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/mappers/OrganizationMapperTest.java
@@ -1,0 +1,25 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.pakland.mdas.githubstats.application.dto.OrganizationDTO;
+import io.pakland.mdas.githubstats.application.dto.TeamDTO;
+import io.pakland.mdas.githubstats.domain.entity.Organization;
+import io.pakland.mdas.githubstats.domain.entity.Team;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class OrganizationMapperTest {
+
+    @Test
+    public void shouldConvertDtoToEntity() {
+        OrganizationDTO dto = Mockito.mock(OrganizationDTO.class);
+        Mockito.when(dto.getId()).thenReturn(1);
+        Mockito.when(dto.getLogin()).thenReturn("github-stats-22");
+
+         Organization entity = OrganizationMapper.dtoToEntity(dto);
+
+        assertEquals(1, (int) entity.getId());
+        assertEquals("github-stats-22", entity.getLogin());
+    }
+}


### PR DESCRIPTION
### Description

- Created `GitHubOrganizationDTO` that allows us to parse the response from the GitHub API
- Added the `OrganizationMapper` that allows us to serice-agnostically convert the DTO to an Entity.
- Added the `OrganizationMapper` to the GitHub repository that required it.

Closes #130 

> This should be merged afetr #138
