### PR TITLE
fix: remove `JsonProperty` from `Repository`

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/RepositoryDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/RepositoryDTO.java
@@ -1,0 +1,7 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+public interface RepositoryDTO {
+    Integer getId();
+    String getName();
+    String getOwnerLogin();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/RepositoryMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/RepositoryMapper.java
@@ -1,0 +1,16 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import io.pakland.mdas.githubstats.application.dto.RepositoryDTO;
+import io.pakland.mdas.githubstats.domain.entity.Repository;
+
+public class RepositoryMapper {
+
+    public static Repository dtoToEntity(RepositoryDTO dto) {
+        return Repository.builder()
+            .id(dto.getId())
+            .name(dto.getName())
+            .ownerLogin(dto.getOwnerLogin())
+            .build();
+    }
+
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/Repository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/Repository.java
@@ -23,11 +23,9 @@ public class Repository {
 
   @Id
   @Column(updatable = false, nullable = false)
-  @JsonProperty("id")
   private Integer id;
 
   @Column(name = "name")
-  @JsonProperty("name")
   private String name;
 
   @Column(name = "owner_login")
@@ -43,11 +41,6 @@ public class Repository {
     orphanRemoval = true
   )
   private List<PullRequest> pullRequests = new ArrayList<>();
-
-  @JsonProperty("owner")
-  private void unpackNameFromNestedObject(Map<String, String> owner) {
-    this.ownerLogin = owner.get("login");
-  }
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubRepositoryDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubRepositoryDTO.java
@@ -1,9 +1,10 @@
 package io.pakland.mdas.githubstats.infrastructure.github.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.RepositoryDTO;
 import java.util.Map;
 
-public class GitHubRepositoryDTO {
+public class GitHubRepositoryDTO implements RepositoryDTO {
 
     @JsonProperty("id")
     private Integer id;
@@ -16,5 +17,20 @@ public class GitHubRepositoryDTO {
     @JsonProperty("owner")
     private void unpackNameFromNestedObject(Map<String, String> owner) {
         this.ownerLogin = owner.get("login");
+    }
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getOwnerLogin() {
+        return this.ownerLogin;
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubRepositoryDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubRepositoryDTO.java
@@ -1,0 +1,20 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public class GitHubRepositoryDTO {
+
+    @JsonProperty("id")
+    private Integer id;
+
+    @JsonProperty("name")
+    private String name;
+
+    private String ownerLogin;
+
+    @JsonProperty("owner")
+    private void unpackNameFromNestedObject(Map<String, String> owner) {
+        this.ownerLogin = owner.get("login");
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/RepositoryGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/RepositoryGitHubRepository.java
@@ -1,8 +1,10 @@
 package io.pakland.mdas.githubstats.infrastructure.github.repository;
 
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.application.mappers.RepositoryMapper;
 import io.pakland.mdas.githubstats.domain.entity.Repository;
 import io.pakland.mdas.githubstats.domain.repository.RepositoryExternalRepository;
+import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubRepositoryDTO;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,10 +25,11 @@ public class RepositoryGitHubRepository implements RepositoryExternalRepository 
         try {
             return this.webClientConfiguration.getWebClient().get()
                 .uri(String.format("/orgs/%s/teams/%s/repos", organizationLogin, teamSlug))
-                    .retrieve()
-                    .bodyToFlux(Repository.class)
-                    .collectList()
-                    .block();
+                .retrieve()
+                .bodyToFlux(GitHubRepositoryDTO.class)
+                .map(RepositoryMapper::dtoToEntity)
+                .collectList()
+                .block();
         } catch (WebClientResponseException ex) {
             logger.error(ex.toString());
             throw new HttpException(ex.getRawStatusCode(), ex.getMessage());

--- a/src/test/java/io/pakland/mdas/githubstats/application/mappers/RepositoryMapperTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/mappers/RepositoryMapperTest.java
@@ -1,0 +1,27 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.pakland.mdas.githubstats.application.dto.RepositoryDTO;
+import io.pakland.mdas.githubstats.application.dto.TeamDTO;
+import io.pakland.mdas.githubstats.domain.entity.Repository;
+import io.pakland.mdas.githubstats.domain.entity.Team;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class RepositoryMapperTest {
+
+    @Test
+    public void shouldConvertDtoToEntity() {
+        RepositoryDTO dto = Mockito.mock(RepositoryDTO.class);
+        Mockito.when(dto.getId()).thenReturn(1);
+        Mockito.when(dto.getName()).thenReturn("github-stats");
+        Mockito.when(dto.getOwnerLogin()).thenReturn("github-stats-22");
+
+        Repository entity = RepositoryMapper.dtoToEntity(dto);
+
+        assertEquals(1, (int) entity.getId());
+        assertEquals("github-stats", entity.getName());
+        assertEquals("github-stats-22", entity.getOwnerLogin());
+    }
+}


### PR DESCRIPTION
### Description

- Created `GitHubRepositoryDTO` that allows us to parse the response from the GitHub API
- Added the `RepositoryMapper` that allows us to serice-agnostically convert the DTO to an Entity.
- Added the `RepositoryMapper` to the GitHub repository that required it.

Closes #130 

> This should be merged after #139