### PR TITLE
feat: fetch comments from pull request

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/CommentDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/CommentDTO.java
@@ -3,5 +3,5 @@ package io.pakland.mdas.githubstats.application.dto;
 public interface CommentDTO {
     Integer getId();
 
-    Integer getLength();
+    String getBody();
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/CommitDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/CommitDTO.java
@@ -1,0 +1,11 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+import java.util.Date;
+
+public interface CommitDTO {
+    String getSha();
+    String getUser();
+    Integer getAdditions();
+    Integer getDeletions();
+    Date getDate();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/PullRequestDTO.java
@@ -2,8 +2,18 @@ package io.pakland.mdas.githubstats.application.dto;
 
 import io.pakland.mdas.githubstats.domain.enums.PullRequestState;
 
+import java.time.Instant;
+
 public interface PullRequestDTO {
     Integer getId();
+
     Integer getNumber();
+
     PullRequestState getState();
+
+    Instant getClosedAt();
+
+    Integer getAdditions();
+
+    Integer getDeletions();
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/external/FetchCommentsFromPullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/external/FetchCommentsFromPullRequest.java
@@ -1,0 +1,34 @@
+package io.pakland.mdas.githubstats.application.external;
+
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.domain.entity.Comment;
+import io.pakland.mdas.githubstats.domain.repository.CommentExternalRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FetchCommentsFromPullRequest {
+    private final CommentExternalRepository commentExternalRepository;
+
+    public FetchCommentsFromPullRequest(CommentExternalRepository commentExternalRepository) {
+        this.commentExternalRepository = commentExternalRepository;
+    }
+
+    public List<Comment> execute(
+            String repositoryOwner, String repositoryName, Integer pullRequestNumber)
+            throws HttpException {
+        int page = 1;
+        List<Comment> commentList = new ArrayList<>();
+        int responseResults;
+        do {
+            List<Comment> apiResults = this.commentExternalRepository.fetchCommentsFromPullRequest(
+                    repositoryOwner, repositoryName, pullRequestNumber, page, 100
+            );
+            commentList.addAll(apiResults);
+            responseResults = apiResults.size();
+            page++;
+        } while (responseResults > 0);
+
+        return commentList;
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/CommentMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/CommentMapper.java
@@ -7,7 +7,7 @@ public class CommentMapper {
     public static Comment dtoToEntity(CommentDTO dto) {
         return Comment.builder()
                 .id(dto.getId())
-                .length(dto.getLength())
+                .body(dto.getBody())
                 .build();
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/CommitMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/CommitMapper.java
@@ -1,0 +1,17 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import io.pakland.mdas.githubstats.application.dto.CommitDTO;
+import io.pakland.mdas.githubstats.domain.entity.Commit;
+
+public class CommitMapper {
+
+    public static Commit dtoToEntity(CommitDTO dto) {
+        return Commit.builder()
+            .sha(dto.getSha())
+            .user(dto.getUser())
+            .additions(dto.getAdditions())
+            .deletions(dto.getDeletions())
+            .date(dto.getDate())
+            .build();
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/Comment.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/Comment.java
@@ -1,24 +1,20 @@
 package io.pakland.mdas.githubstats.domain.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
+import lombok.*;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Comment {
+
     private Integer id;
 
     private UserReview userReview;
 
     private String body;
 
-    public Integer getBodyLength() {
+    public Integer getLength() {
         return this.body.length();
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/Comment.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/Comment.java
@@ -12,10 +12,13 @@ import javax.persistence.*;
 @AllArgsConstructor
 @Builder
 public class Comment {
-
     private Integer id;
 
     private UserReview userReview;
 
-    private int length;
+    private String body;
+
+    public Integer getBodyLength() {
+        return this.body.length();
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/Commit.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/Commit.java
@@ -1,47 +1,28 @@
 package io.pakland.mdas.githubstats.domain.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Objects;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-
-import javax.persistence.*;
-import java.time.Instant;
 import java.util.Date;
-import java.util.Map;
+import lombok.*;
 
 @Data
 @NoArgsConstructor
 @ToString
+@AllArgsConstructor
+@Builder
 public class Commit {
 
-    @JsonProperty("sha")
     private String sha;
+
+    private String user;
+
+    private Integer additions;
+
+    private Integer deletions;
 
     private Date date;
 
-    private User user;
-
     private PullRequest pullRequest;
 
-    private int additions;
-
-    private int deletions;
-
-    @JsonProperty("commit")
-    private void unpackDateFromNestedObject(Map<String, Object> commitJson) {
-        Map<String, Object> committer = (Map<String, Object>)commitJson.get("committer");
-        this.date = Date.from(Instant.parse(committer.get("date").toString()));
-    }
-
-    @JsonProperty("stats")
-    private void setAdditionDeletionsLines(Map<String, Object> stats) {
-        additions = Integer.parseInt(stats.get("additions").toString());
-        deletions = Integer.parseInt(stats.get("deletions").toString());
-    }
-
-    // The hashcde must be overridden otherwise it causes a stakoverflow issue
+    // The hashcode must be overridden otherwise it causes a stackoverflow issue
     // when adding a commit to a set like structure
     @Override
     public int hashCode() {

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/CommitAggregation.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/CommitAggregation.java
@@ -13,8 +13,6 @@ public class CommitAggregation implements CSVExportable {
     public static CommitAggregation aggregate(List<Commit> commits) {
         CommitAggregation commitAggregation = new CommitAggregation();
         commitAggregation.numCommits = (int) commits.stream().distinct().count();
-        commitAggregation.linesAdded = commits.stream().mapToInt(Commit::getAdditions).sum();
-        commitAggregation.linesRemoved = commits.stream().mapToInt(Commit::getDeletions).sum();
         return commitAggregation;
     }
 
@@ -22,9 +20,13 @@ public class CommitAggregation implements CSVExportable {
         return numCommits;
     }
 
-    public int getLinesAdded() { return linesAdded; }
+    public int getLinesAdded() {
+        return linesAdded;
+    }
 
-    public int getLinesRemoved() { return linesRemoved; }
+    public int getLinesRemoved() {
+        return linesRemoved;
+    }
 
     @Override
     public String toCSV() {

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/CommitAggregation.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/CommitAggregation.java
@@ -6,9 +6,6 @@ public class CommitAggregation implements CSVExportable {
 
     private int numCommits;
 
-    private int linesAdded;
-
-    private int linesRemoved;
 
     public static CommitAggregation aggregate(List<Commit> commits) {
         CommitAggregation commitAggregation = new CommitAggregation();
@@ -20,21 +17,13 @@ public class CommitAggregation implements CSVExportable {
         return numCommits;
     }
 
-    public int getLinesAdded() {
-        return linesAdded;
-    }
-
-    public int getLinesRemoved() {
-        return linesRemoved;
-    }
-
     @Override
     public String toCSV() {
         String sep = ",";
         String lineSep = "\n";
 
-        List<String> metrics = List.of("numCommits", "linesAdded", "linesRemoved");
-        List<Object> data = List.of(numCommits, linesAdded, linesRemoved);
+        List<String> metrics = List.of("numCommits");
+        List<Object> data = List.of(numCommits);
 
         String header = String.join(sep, metrics);
         String body = String.join(sep, data.stream().map(Object::toString).toList());

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequest.java
@@ -1,9 +1,9 @@
 package io.pakland.mdas.githubstats.domain.entity;
 
+import io.pakland.mdas.githubstats.domain.enums.PullRequestState;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import io.pakland.mdas.githubstats.domain.enums.PullRequestState;
 import lombok.*;
 
 @Data
@@ -17,6 +17,12 @@ public class PullRequest {
     private Integer number;
 
     private PullRequestState state;
+
+    private Instant closedAt;
+
+    private Integer additions;
+
+    private Integer deletions;
 
     @ToString.Exclude
     private Repository repository;
@@ -37,26 +43,4 @@ public class PullRequest {
             this.commits.add(commit);
         });
     }
-    public List<Commit> getCommitsByUser(User user) {
-        return commits
-            .stream()
-            .filter(commit -> commit.getUser().equals(user))
-            .collect(Collectors.toList());
-    }
-
-    public boolean isClosed() {
-        return state.equals(PullRequestState.CLOSED);
-    }
-
-    public boolean isCreatedByUser(User user) {
-        return this.user.equals(user);
-    }
-
-    public List<UserReview> getReviewsFromUser(User user) {
-        return userReviews
-            .stream()
-            .filter(x -> x.getUser().equals(user))
-            .collect(Collectors.toList());
-    }
-
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequest.java
@@ -3,7 +3,6 @@ package io.pakland.mdas.githubstats.domain.entity;
 import io.pakland.mdas.githubstats.domain.enums.PullRequestState;
 import java.time.Instant;
 import java.util.*;
-import java.util.stream.Collectors;
 import lombok.*;
 
 @Data

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequestAggregation.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/PullRequestAggregation.java
@@ -3,6 +3,17 @@ package io.pakland.mdas.githubstats.domain.entity;
 import java.util.List;
 
 public class PullRequestAggregation implements CSVExportable {
+    private int linesAdded;
+
+    private int linesRemoved;
+
+    public int getLinesAdded() {
+        return linesAdded;
+    }
+
+    public int getLinesRemoved() {
+        return linesRemoved;
+    }
 
     public PullRequestAggregation aggregate(List<PullRequest> pullRequests) {
         // TODO

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/UserReview.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/UserReview.java
@@ -1,11 +1,10 @@
 package io.pakland.mdas.githubstats.domain.entity;
 
-import javax.persistence.*;
-
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,24 +21,12 @@ public class UserReview {
 
   private List<Comment> comments = new ArrayList<>();
 
-  public int sumCommentLength() {
-    return comments.stream().mapToInt(Comment::getLength).sum();
-  }
+    public int sumCommentLength() {
+        return comments.stream().mapToInt(Comment::getLength).sum();
+    }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof UserReview )) return false;
-    return id != null && id.equals(((UserReview) o).getId());
-  }
-
-  @Override
-  public int hashCode() {
-    return getClass().hashCode();
-  }
-
-  public boolean isReviewFromTeam(Team team) {
-    return pullRequest.getRepository().getTeam().equals(team);
-  }
+    public boolean isReviewFromTeam(Team team) {
+        return pullRequest.getRepository().getTeam().equals(team);
+    }
 
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/repository/CommentExternalRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/repository/CommentExternalRepository.java
@@ -1,0 +1,11 @@
+package io.pakland.mdas.githubstats.domain.repository;
+
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.domain.entity.Comment;
+
+import java.util.List;
+
+public interface CommentExternalRepository {
+    public List<Comment> fetchCommentsFromPullRequest(
+            String repositoryOwner, String repositoryName, Integer pullRequestNumber, Integer page, Integer perPage) throws HttpException;
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommentDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommentDTO.java
@@ -22,7 +22,7 @@ public class GitHubCommentDTO implements CommentDTO {
     }
 
     @Override
-    public Integer getLength() {
-        return this.body.length();
+    public String getBody() {
+        return this.body;
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommitDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommitDTO.java
@@ -1,0 +1,64 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.CommitDTO;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitHubCommitDTO implements CommitDTO {
+    @JsonProperty("sha")
+    private String sha;
+
+    @JsonProperty("user")
+    private String user;
+
+    private Integer additions;
+
+    private Integer deletions;
+
+    private Date date;
+
+    @JsonProperty("commit")
+    private void unpackDateFromNestedObject(Map<String, Object> commitJson) {
+        Map<String, Object> committer = (Map<String, Object>)commitJson.get("committer");
+        this.date = Date.from(Instant.parse(committer.get("date").toString()));
+    }
+
+    @JsonProperty("stats")
+    private void setAdditionDeletionsLines(Map<String, Object> stats) {
+        additions = Integer.parseInt(stats.get("additions").toString());
+        deletions = Integer.parseInt(stats.get("deletions").toString());
+    }
+
+    @Override
+    public String getSha() {
+        return this.sha;
+    }
+
+    @Override
+    public String getUser() {
+        return this.user;
+    }
+
+    @Override
+    public Integer getDeletions() {
+        return this.deletions;
+    }
+
+    @Override
+    public Integer getAdditions() {
+        return this.additions;
+    }
+
+    @Override
+    public Date getDate() {
+        return this.date;
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommitDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommitDTO.java
@@ -9,6 +9,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
@@ -5,6 +5,8 @@ import io.pakland.mdas.githubstats.application.dto.PullRequestDTO;
 import io.pakland.mdas.githubstats.application.dto.PullRequestStateDTO;
 import io.pakland.mdas.githubstats.domain.enums.PullRequestState;
 
+import java.time.Instant;
+
 public class GitHubPullRequestDTO implements PullRequestDTO {
 
     @JsonProperty("id")
@@ -15,6 +17,15 @@ public class GitHubPullRequestDTO implements PullRequestDTO {
 
     @JsonProperty("state")
     private PullRequestStateDTO state;
+
+    @JsonProperty("closed_at")
+    private Instant closedAt;
+
+    @JsonProperty("additions")
+    private Integer additions;
+
+    @JsonProperty("deletions")
+    private Integer deletions;
 
     @Override
     public Integer getId() {
@@ -31,4 +42,18 @@ public class GitHubPullRequestDTO implements PullRequestDTO {
         return this.state.getValue();
     }
 
+    @Override
+    public Instant getClosedAt() {
+        return this.closedAt;
+    }
+
+    @Override
+    public Integer getAdditions() {
+        return this.additions;
+    }
+
+    @Override
+    public Integer getDeletions() {
+        return this.deletions;
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommentGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommentGitHubRepository.java
@@ -1,0 +1,48 @@
+package io.pakland.mdas.githubstats.infrastructure.github.repository;
+
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.application.mappers.CommentMapper;
+import io.pakland.mdas.githubstats.domain.entity.Comment;
+import io.pakland.mdas.githubstats.domain.repository.CommentExternalRepository;
+import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubCommentDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+
+public class CommentGitHubRepository implements CommentExternalRepository {
+    private final WebClientConfiguration webClientConfiguration;
+    private final Logger logger = LoggerFactory.getLogger(CommentGitHubRepository.class);
+
+    public CommentGitHubRepository(WebClientConfiguration webClientConfiguration) {
+        this.webClientConfiguration = webClientConfiguration;
+    }
+
+    @Override
+    public List<Comment> fetchCommentsFromPullRequest(
+            String repositoryOwner, String repositoryName, Integer pullRequestNumber, Integer page, Integer perPage)
+            throws HttpException {
+
+        try {
+
+            return this.webClientConfiguration.getWebClient().get()
+                    .uri(String.format("/repos/%s/%s/pulls/%s/comments?%s", repositoryOwner,
+                            repositoryName, pullRequestNumber, getRequestParams(page, perPage)))
+                    .retrieve()
+                    .bodyToFlux(GitHubCommentDTO.class)
+                    .map(CommentMapper::dtoToEntity)
+                    .collectList()
+                    .block();
+
+        } catch (WebClientResponseException ex) {
+            logger.error(ex.toString());
+            throw new HttpException(ex.getRawStatusCode(), ex.getMessage());
+        }
+    }
+
+    private String getRequestParams(Integer page, Integer perPage) {
+        return String.format("per_page=%d&page=%d", perPage, page < 0 ? 1 : page);
+    }
+
+}

--- a/src/test/java/io/pakland/mdas/githubstats/application/external/FetchCommitsFromPullRequestTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/external/FetchCommitsFromPullRequestTest.java
@@ -30,19 +30,19 @@ public class FetchCommitsFromPullRequestTest {
     @Test
     public void whenValidRepository_shouldReturnTheListOfCommits()
         throws HttpException {
-        Commit commit = new Commit();
-        commit.setSha("a0b3ed9d5f1356575f2b16ab8ef5d93c5ce77575");
-        commit.setDate(new Date());
-        Commit commit1 = new Commit();
-        commit1.setSha("f16b593d35d6e66dc7e1c8727d4eaa829d3973ed");
-        commit1.setDate(new Date());
+        Commit commitOne = Commit.builder().sha(
+            "a0b3ed9d5f1356575f2b16ab8ef5d93c5ce77575"
+        ).date(new Date()).additions(250).deletions(125).build();
+        Commit commitTwo = Commit.builder().sha(
+            "f16b593d35d6e66dc7e1c8727d4eaa829d3973ed"
+        ).date(new Date()).additions(250).deletions(125).build();
 
         CommitExternalRepository repository = Mockito.mock(
             CommitExternalRepository.class);
 
         Mockito.when(repository.fetchCommitsFromPullRequest(Mockito.any(
                 FetchCommitsFromPullRequestRequest.class)))
-            .thenReturn(new ArrayList<>(Arrays.asList(commit, commit1)))
+            .thenReturn(new ArrayList<>(Arrays.asList(commitOne, commitTwo)))
             .thenReturn(new ArrayList<>());
 
         List<Commit> response = new FetchCommitsFromPullRequest(repository).execute(
@@ -56,8 +56,8 @@ public class FetchCommitsFromPullRequestTest {
         assertEquals(2, captor.getValue().getPage());
         assertEquals(100, captor.getValue().getPerPage());
         assertEquals(2, response.size());
-        assertEquals(commit.getSha(), response.get(0).getSha());
-        assertEquals(commit1.getSha(), response.get(1).getSha());
+        assertEquals(commitOne.getSha(), response.get(0).getSha());
+        assertEquals(commitTwo.getSha(), response.get(1).getSha());
     }
 
     @Test

--- a/src/test/java/io/pakland/mdas/githubstats/application/internal/AggregateUserReviewsTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/application/internal/AggregateUserReviewsTest.java
@@ -1,16 +1,15 @@
 package io.pakland.mdas.githubstats.application.internal;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.pakland.mdas.githubstats.domain.entity.Comment;
 import io.pakland.mdas.githubstats.domain.entity.UserReview;
 import io.pakland.mdas.githubstats.domain.entity.UserReviewAggregation;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class AggregateUserReviewsTest {
 
@@ -26,7 +25,7 @@ public class AggregateUserReviewsTest {
             for (int j = 0; j < 10; j++) {
                 Comment comment = Mockito.mock(Comment.class);
                 int randomLength = random.nextInt(10);
-                comment.setLength(randomLength);
+                comment.setBody(" ".repeat(randomLength));
                 comments.add(comment);
                 sum += comment.getLength();  // accumulate comment length to assert at the end
             }


### PR DESCRIPTION
- `fetchCommentsFromPullRequest` use case.
- change the way we obtain the number of lines added/deleted. As stated in classroom, we should obtain them from the pull request object instead of the commit object.
- Small refactor of code implied with the lines additions and deletions.

closes #141 