### PR TITLE
feat: major improvements on efficiency

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/Commit.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/Commit.java
@@ -26,10 +26,6 @@ public class Commit {
     // when adding a commit to a set like structure
     @Override
     public int hashCode() {
-        int result = sha.hashCode();
-        result = 31 * result + (date != null ? date.hashCode() : 0);
-        result = 31 * result + additions;
-        result = 31 * result + deletions;
-        return result;
+        return sha.hashCode();
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/lib/InternalCaching.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/lib/InternalCaching.java
@@ -1,0 +1,46 @@
+package io.pakland.mdas.githubstats.domain.lib;
+
+import java.util.*;
+
+public class InternalCaching<K, T> {
+
+    private final Map<K, Integer> cacheIndex = new HashMap<>();
+    private final List<T> cacheStore = new ArrayList<>();
+
+    public InternalCaching() {
+    }
+
+    protected boolean has(K key) {
+        return this.cacheIndex.containsKey(key);
+    }
+
+    protected Integer size() {
+        return this.cacheIndex.size();
+    }
+
+    public void add(K key, T value) {
+        if (!cacheIndex.containsKey(key)) {
+            cacheStore.add(value);
+            cacheIndex.put(key, cacheStore.size() - 1);
+        }
+    }
+
+    public T get(K key) {
+        Integer index = cacheIndex.get(key);
+        if (index == null) {
+            return null;
+        }
+        return cacheStore.get(index);
+    }
+
+    public T delete(K key) {
+        Integer index = cacheIndex.get(key);
+        if (index == null) {
+            return null;
+        }
+        T element = cacheStore.get(index);
+        cacheStore.remove(element);
+        cacheIndex.remove(key);
+        return element;
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestDTO.java
@@ -16,7 +16,7 @@ public class GitHubPullRequestDTO implements PullRequestDTO {
     private Integer number;
 
     @JsonProperty("state")
-    private PullRequestStateDTO state;
+    private GitHubPullRequestStateDTO state;
 
     @JsonProperty("closed_at")
     private Instant closedAt;

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestStateDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubPullRequestStateDTO.java
@@ -3,7 +3,9 @@ package io.pakland.mdas.githubstats.infrastructure.github.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.pakland.mdas.githubstats.application.dto.PullRequestStateDTO;
 import io.pakland.mdas.githubstats.domain.enums.PullRequestState;
+import lombok.AllArgsConstructor;
 
+@AllArgsConstructor
 public class GitHubPullRequestStateDTO implements PullRequestStateDTO {
 
     @JsonProperty("state")

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommentGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommentGitHubRepository.java
@@ -5,15 +5,18 @@ import io.pakland.mdas.githubstats.application.mappers.CommentMapper;
 import io.pakland.mdas.githubstats.domain.entity.Comment;
 import io.pakland.mdas.githubstats.domain.repository.CommentExternalRepository;
 import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubCommentDTO;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import java.util.List;
-
 public class CommentGitHubRepository implements CommentExternalRepository {
+
     private final WebClientConfiguration webClientConfiguration;
     private final Logger logger = LoggerFactory.getLogger(CommentGitHubRepository.class);
+
+    private final Map<Integer, Integer> internalQueryCache = new HashMap<>();
+    private final List<List<Comment>> commentStore = new ArrayList<>();
 
     public CommentGitHubRepository(WebClientConfiguration webClientConfiguration) {
         this.webClientConfiguration = webClientConfiguration;
@@ -21,19 +24,29 @@ public class CommentGitHubRepository implements CommentExternalRepository {
 
     @Override
     public List<Comment> fetchCommentsFromPullRequest(
-            String repositoryOwner, String repositoryName, Integer pullRequestNumber, Integer page, Integer perPage)
-            throws HttpException {
+        String repositoryOwner, String repositoryName, Integer pullRequestNumber, Integer page,
+        Integer perPage)
+        throws HttpException {
+        String query = String.format("/repos/%s/%s/pulls/%s/comments?%s", repositoryOwner,
+            repositoryName, pullRequestNumber, getRequestParams(page, perPage));
+        Integer dataPosition = internalQueryCache.get(query.hashCode());
+        if (dataPosition != null) {
+            return commentStore.get(dataPosition);
+        }
 
         try {
+            logger.info(" - Fetching comments from pull request: " + pullRequestNumber);
+            List<Comment> result = this.webClientConfiguration.getWebClient().get()
+                .uri(query)
+                .retrieve()
+                .bodyToFlux(GitHubCommentDTO.class)
+                .map(CommentMapper::dtoToEntity)
+                .collectList()
+                .block();
+            commentStore.add(result);
+            internalQueryCache.put(query.hashCode(), commentStore.size() - 1);
 
-            return this.webClientConfiguration.getWebClient().get()
-                    .uri(String.format("/repos/%s/%s/pulls/%s/comments?%s", repositoryOwner,
-                            repositoryName, pullRequestNumber, getRequestParams(page, perPage)))
-                    .retrieve()
-                    .bodyToFlux(GitHubCommentDTO.class)
-                    .map(CommentMapper::dtoToEntity)
-                    .collectList()
-                    .block();
+            return result;
 
         } catch (WebClientResponseException ex) {
             logger.error(ex.toString());

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommitGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommitGitHubRepository.java
@@ -5,34 +5,49 @@ import io.pakland.mdas.githubstats.application.mappers.CommitMapper;
 import io.pakland.mdas.githubstats.domain.entity.Commit;
 import io.pakland.mdas.githubstats.domain.repository.CommitExternalRepository;
 import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubCommitDTO;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import java.util.List;
-
 public class CommitGitHubRepository implements CommitExternalRepository {
+
     private final WebClientConfiguration webClientConfiguration;
     private final Logger logger = LoggerFactory.getLogger(CommitGitHubRepository.class);
+
+    private final Map<Integer, Integer> internalQueryCache = new HashMap<>();
+    private final List<List<Commit>> commitStore = new ArrayList<>();
 
     public CommitGitHubRepository(WebClientConfiguration webClientConfiguration) {
         this.webClientConfiguration = webClientConfiguration;
     }
 
     @Override
-    public List<Commit> fetchCommitsFromPullRequest(FetchCommitsFromPullRequestRequest request) throws HttpException {
+    public List<Commit> fetchCommitsFromPullRequest(FetchCommitsFromPullRequestRequest request)
+        throws HttpException {
+        String query = String.format("/repos/%s/%s/pulls/%s/commits?%s",
+            request.getRepositoryOwner(),
+            request.getRepositoryName(), request.getPullRequestNumber(),
+            getRequestParams(request));
+        Integer resultPosition = internalQueryCache.get(query.hashCode());
+        if (resultPosition != null) {
+            return commitStore.get(resultPosition);
+        }
 
         try {
+            logger.info(" - Fetching commits for pull request: " + request.getPullRequestNumber()
+                .toString());
+            List<Commit> result = this.webClientConfiguration.getWebClient().get()
+                .uri(query)
+                .retrieve()
+                .bodyToFlux(GitHubCommitDTO.class)
+                .map(CommitMapper::dtoToEntity)
+                .collectList()
+                .block();
+            commitStore.add(result);
+            internalQueryCache.put(query.hashCode(), commitStore.size() - 1);
 
-            return this.webClientConfiguration.getWebClient().get()
-                    .uri(String.format("/repos/%s/%s/pulls/%s/commits?%s", request.getRepositoryOwner(),
-                            request.getRepositoryName(), request.getPullRequestNumber(), getRequestParams(request)))
-                    .retrieve()
-                    .bodyToFlux(GitHubCommitDTO.class)
-                    .map(CommitMapper::dtoToEntity)
-                    .collectList()
-                    .block();
-
+            return result;
         } catch (WebClientResponseException ex) {
             logger.error(ex.toString());
             throw new HttpException(ex.getRawStatusCode(), ex.getMessage());
@@ -40,6 +55,7 @@ public class CommitGitHubRepository implements CommitExternalRepository {
     }
 
     private String getRequestParams(FetchCommitsFromPullRequestRequest request) {
-        return String.format("per_page=%d&page=%d", request.getPerPage(), request.getPage() < 0 ? 1 : request.getPage());
+        return String.format("per_page=%d&page=%d", request.getPerPage(),
+            request.getPage() < 0 ? 1 : request.getPage());
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/OrganizationGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/OrganizationGitHubRepository.java
@@ -22,6 +22,7 @@ public class OrganizationGitHubRepository implements OrganizationExternalReposit
     @Override
     public List<Organization> fetchAvailableOrganizations() throws HttpException {
         try {
+            logger.info(" - Fetching organizations");
             return this.webClientConfiguration.getWebClient().get()
                 .uri("/user/orgs")
                 .retrieve()

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/PullRequestGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/PullRequestGitHubRepository.java
@@ -23,6 +23,9 @@ public class PullRequestGitHubRepository implements PullRequestExternalRepositor
     public List<PullRequest> fetchPullRequestsFromRepository(
         FetchPullRequestFromRepositoryRequest request) throws HttpException {
         try {
+            logger.info(
+                " - Fetching pull requests from repository: " + request.getRepositoryOwner() + "/"
+                    + request.getRepository());
             return this.webClientConfiguration.getWebClient().get()
                 .uri(String.format("/repos/%s/%s/pulls?%s", request.getRepositoryOwner(),
                     request.getRepository(), getRequestParams(request)))

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/RepositoryGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/RepositoryGitHubRepository.java
@@ -23,6 +23,7 @@ public class RepositoryGitHubRepository implements RepositoryExternalRepository 
     public List<Repository> fetchTeamRepositories(String organizationLogin, String teamSlug)
         throws HttpException {
         try {
+            logger.info(" - Fetching repositories for team: " + organizationLogin + "/" + teamSlug);
             return this.webClientConfiguration.getWebClient().get()
                 .uri(String.format("/orgs/%s/teams/%s/repos", organizationLogin, teamSlug))
                 .retrieve()

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/TeamGitHubRepository.java
@@ -22,6 +22,7 @@ public class TeamGitHubRepository implements TeamExternalRepository {
     @Override
     public List<Team> fetchTeamsFromOrganization(String organizationName) throws HttpException {
         try {
+            logger.info(" - Fetching teams from organization: " + organizationName);
             return this.webClientConfiguration.getWebClient().get()
                 .uri(String.format("/orgs/%s/teams", organizationName))
                 .retrieve()

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/UserGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/UserGitHubRepository.java
@@ -25,6 +25,7 @@ public class UserGitHubRepository implements UserExternalRepository {
     public List<User> fetchUsersFromTeam(String organizationName, String teamName)
         throws HttpException {
         try {
+            logger.info(" - Fetching users from team: " + organizationName + "/" + teamName);
             return this.webClientConfiguration.getWebClient().get()
                 .uri(String.format("/orgs/%s/teams/%s/members", organizationName, teamName))
                 .retrieve()

--- a/src/test/java/io/pakland/mdas/githubstats/domain/entity/CSVTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/entity/CSVTest.java
@@ -1,4 +1,4 @@
-package io.pakland.mdas.githubstats.domain;
+package io.pakland.mdas.githubstats.domain.entity;
 
 import java.util.List;
 

--- a/src/test/java/io/pakland/mdas/githubstats/domain/entity/CommitAggregationTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/entity/CommitAggregationTest.java
@@ -1,13 +1,10 @@
-package io.pakland.mdas.githubstats.domain;
-
-import io.pakland.mdas.githubstats.domain.entity.Commit;
-import io.pakland.mdas.githubstats.domain.entity.CommitAggregation;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
+package io.pakland.mdas.githubstats.domain.entity;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 public class CommitAggregationTest extends CSVTest {
 

--- a/src/test/java/io/pakland/mdas/githubstats/domain/entity/OrganizationTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/entity/OrganizationTest.java
@@ -1,4 +1,4 @@
-package io.pakland.mdas.githubstats.domain;
+package io.pakland.mdas.githubstats.domain.entity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/src/test/java/io/pakland/mdas/githubstats/domain/entity/PullRequestAggregationTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/entity/PullRequestAggregationTest.java
@@ -1,7 +1,5 @@
-package io.pakland.mdas.githubstats.domain;
+package io.pakland.mdas.githubstats.domain.entity;
 
-import io.pakland.mdas.githubstats.domain.entity.PullRequest;
-import io.pakland.mdas.githubstats.domain.entity.PullRequestAggregation;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/src/test/java/io/pakland/mdas/githubstats/domain/entity/TeamTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/entity/TeamTest.java
@@ -1,4 +1,4 @@
-package io.pakland.mdas.githubstats.domain;
+package io.pakland.mdas.githubstats.domain.entity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/src/test/java/io/pakland/mdas/githubstats/domain/entity/UserReviewAggregationTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/entity/UserReviewAggregationTest.java
@@ -1,6 +1,5 @@
-package io.pakland.mdas.githubstats.domain;
+package io.pakland.mdas.githubstats.domain.entity;
 
-import io.pakland.mdas.githubstats.domain.entity.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/src/test/java/io/pakland/mdas/githubstats/domain/entity/UserTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/entity/UserTest.java
@@ -1,4 +1,4 @@
-package io.pakland.mdas.githubstats.domain;
+package io.pakland.mdas.githubstats.domain.entity;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/pakland/mdas/githubstats/domain/lib/InternalCachingTest.java
+++ b/src/test/java/io/pakland/mdas/githubstats/domain/lib/InternalCachingTest.java
@@ -1,0 +1,63 @@
+package io.pakland.mdas.githubstats.domain.lib;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class InternalCachingTest {
+
+    @Test
+    public void shouldAddAnElement() {
+        InternalCaching<Integer, Integer> cache = new InternalCaching<>();
+        cache.add(1, 1);
+        assertTrue(cache.has(1));
+        assertEquals(cache.size(), 1);
+    }
+
+    @Test
+    public void shouldNotAddRepeatedElement() {
+        InternalCaching<Integer, Integer> cache = new InternalCaching<>();
+        cache.add(1, 1);
+        cache.add(2, 1);
+        assertTrue(cache.has(1));
+        assertTrue(cache.has(2));
+        assertEquals(cache.size(), 2);
+
+        cache.add(2, 1);
+        assertEquals(cache.size(), 2);
+    }
+
+    @Test
+    public void shouldReturnAnElementIfExists() {
+        InternalCaching<Integer, Integer> cache = new InternalCaching<>();
+        cache.add(3, 1);
+        assertEquals(cache.get(3), 1);
+    }
+
+    @Test
+    public void shouldReturnNullIfKeyDoesNotExist(){
+        InternalCaching<Integer, Integer> cache = new InternalCaching<>();
+        cache.add(3, 1);
+        assertNull(cache.get(4));
+    }
+
+    @Test
+    public void shouldDeleteExistingElement() {
+        InternalCaching<Integer, Integer> cache = new InternalCaching<>();
+        cache.add(4, 1);
+        assertEquals(cache.size(), 1);
+
+        assertEquals(cache.delete(4), 1);
+        assertEquals(cache.size(), 0);
+    }
+
+    @Test
+    public void shouldReturnNullIfDeletingNonExistingElement() {
+        InternalCaching<Integer, Integer> cache = new InternalCaching<>();
+        cache.add(4, 1);
+        assertEquals(cache.size(), 1);
+        assertNull(cache.delete(5));
+    }
+}


### PR DESCRIPTION
- Added an internal cache to avoid executing the same query when there are many teams in the same repository. This requests the same pull requests for each team, which translates on fetching the same comments and commits which is a really demanding task.
- Added logged so that we are aware of what is being done in the background. We can add an option to make it silent by default.
- Other minor improvements.
