### PR TITLE
feat: `fetchReviewsFromPullRequest` use case

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/UserReviewDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/UserReviewDTO.java
@@ -1,0 +1,5 @@
+package io.pakland.mdas.githubstats.application.dto;
+
+public interface UserReviewDTO {
+    Integer getId();
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/external/FetchCommentsFromPullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/external/FetchCommentsFromPullRequest.java
@@ -2,6 +2,8 @@ package io.pakland.mdas.githubstats.application.external;
 
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import io.pakland.mdas.githubstats.domain.entity.Comment;
+import io.pakland.mdas.githubstats.domain.entity.PullRequest;
+import io.pakland.mdas.githubstats.domain.entity.Repository;
 import io.pakland.mdas.githubstats.domain.repository.CommentExternalRepository;
 
 import java.util.ArrayList;
@@ -14,16 +16,20 @@ public class FetchCommentsFromPullRequest {
         this.commentExternalRepository = commentExternalRepository;
     }
 
-    public List<Comment> execute(
-            String repositoryOwner, String repositoryName, Integer pullRequestNumber)
-            throws HttpException {
-        int page = 1;
+    public List<Comment> execute(PullRequest pullRequest) throws HttpException {
+        Integer page = 1;
         List<Comment> commentList = new ArrayList<>();
-        int responseResults;
+        Integer responseResults;
+        Repository repository = pullRequest.getRepository();
         do {
-            List<Comment> apiResults = this.commentExternalRepository.fetchCommentsFromPullRequest(
-                    repositoryOwner, repositoryName, pullRequestNumber, page, 100
-            );
+            CommentExternalRepository.FetchCommentsFromPullRequestRequest request = CommentExternalRepository.FetchCommentsFromPullRequestRequest.builder()
+                    .repositoryOwner(repository.getOwnerLogin())
+                    .repositoryName(repository.getName())
+                    .pullRequestNumber(pullRequest.getNumber())
+                    .page(page)
+                    .perPage(100)
+                    .build();
+            List<Comment> apiResults = this.commentExternalRepository.fetchCommentsFromPullRequest(request);
             commentList.addAll(apiResults);
             responseResults = apiResults.size();
             page++;

--- a/src/main/java/io/pakland/mdas/githubstats/application/external/FetchReviewsFromPullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/external/FetchReviewsFromPullRequest.java
@@ -1,0 +1,41 @@
+package io.pakland.mdas.githubstats.application.external;
+
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.domain.entity.PullRequest;
+import io.pakland.mdas.githubstats.domain.entity.Repository;
+import io.pakland.mdas.githubstats.domain.entity.UserReview;
+import io.pakland.mdas.githubstats.domain.repository.ReviewExternalRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FetchReviewsFromPullRequest {
+    private final ReviewExternalRepository reviewExternalRepository;
+
+    public FetchReviewsFromPullRequest(ReviewExternalRepository reviewExternalRepository) {
+        this.reviewExternalRepository = reviewExternalRepository;
+    }
+
+    public List<UserReview> execute(PullRequest pullRequest)
+            throws HttpException {
+        int page = 1;
+        List<UserReview> reviewList = new ArrayList<>();
+        int responseResults;
+        Repository repository = pullRequest.getRepository();
+        do {
+            ReviewExternalRepository.FetchReviewsFromPullRequestRequest request = ReviewExternalRepository.FetchReviewsFromPullRequestRequest.builder()
+                    .repositoryOwner(repository.getOwnerLogin())
+                    .repositoryName(repository.getName())
+                    .pullRequestNumber(pullRequest.getNumber())
+                    .page(page)
+                    .perPage(100)
+                    .build();
+            List<UserReview> apiResults = this.reviewExternalRepository.fetchReviewsFromPullRequest(request);
+            reviewList.addAll(apiResults);
+            responseResults = apiResults.size();
+            page++;
+        } while (responseResults > 0);
+
+        return reviewList;
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/ReviewMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/ReviewMapper.java
@@ -1,0 +1,12 @@
+package io.pakland.mdas.githubstats.application.mappers;
+
+import io.pakland.mdas.githubstats.application.dto.UserReviewDTO;
+import io.pakland.mdas.githubstats.domain.entity.UserReview;
+
+public class ReviewMapper {
+    public static UserReview dtoToEntity(UserReviewDTO dto) {
+        return UserReview.builder()
+                .id(dto.getId())
+                .build();
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/UserReview.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/UserReview.java
@@ -1,25 +1,26 @@
 package io.pakland.mdas.githubstats.domain.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
-import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
 @NoArgsConstructor
-@ToString
+@AllArgsConstructor
+@Builder
 public class UserReview {
 
-  private Integer id;
+    private Integer id;
 
-  private User user;
+    private User user;
 
-  private PullRequest pullRequest;
+    private PullRequest pullRequest;
 
-  private List<Comment> comments = new ArrayList<>();
+    private List<Comment> comments = new ArrayList<>();
 
     public int sumCommentLength() {
         return comments.stream().mapToInt(Comment::getLength).sum();

--- a/src/main/java/io/pakland/mdas/githubstats/domain/repository/CommentExternalRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/repository/CommentExternalRepository.java
@@ -2,10 +2,26 @@ package io.pakland.mdas.githubstats.domain.repository;
 
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import io.pakland.mdas.githubstats.domain.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 public interface CommentExternalRepository {
-    public List<Comment> fetchCommentsFromPullRequest(
-            String repositoryOwner, String repositoryName, Integer pullRequestNumber, Integer page, Integer perPage) throws HttpException;
+
+    public List<Comment> fetchCommentsFromPullRequest(FetchCommentsFromPullRequestRequest request) throws HttpException;
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    public static class FetchCommentsFromPullRequestRequest {
+        private String repositoryOwner;
+        private String repositoryName;
+        private Integer pullRequestNumber;
+        private Integer page;
+        private Integer perPage;
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/repository/ReviewExternalRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/repository/ReviewExternalRepository.java
@@ -1,0 +1,27 @@
+package io.pakland.mdas.githubstats.domain.repository;
+
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.domain.entity.UserReview;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public interface ReviewExternalRepository {
+
+    public List<UserReview> fetchReviewsFromPullRequest(FetchReviewsFromPullRequestRequest request) throws HttpException;
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    public static class FetchReviewsFromPullRequestRequest {
+        private String repositoryOwner;
+        private String repositoryName;
+        private Integer pullRequestNumber;
+        private Integer page;
+        private Integer perPage;
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubReviewDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubReviewDTO.java
@@ -1,0 +1,20 @@
+package io.pakland.mdas.githubstats.infrastructure.github.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.pakland.mdas.githubstats.application.dto.UserReviewDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitHubReviewDTO implements UserReviewDTO {
+    @JsonProperty("id")
+    private Integer id;
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommentGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommentGitHubRepository.java
@@ -6,7 +6,7 @@ import io.pakland.mdas.githubstats.domain.entity.Comment;
 import io.pakland.mdas.githubstats.domain.lib.InternalCaching;
 import io.pakland.mdas.githubstats.domain.repository.CommentExternalRepository;
 import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubCommentDTO;
-import java.util.*;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -23,19 +23,18 @@ public class CommentGitHubRepository implements CommentExternalRepository {
     }
 
     @Override
-    public List<Comment> fetchCommentsFromPullRequest(
-        String repositoryOwner, String repositoryName, Integer pullRequestNumber, Integer page,
-        Integer perPage)
+    public List<Comment> fetchCommentsFromPullRequest(FetchCommentsFromPullRequestRequest request)
         throws HttpException {
-        String query = String.format("/repos/%s/%s/pulls/%s/comments?%s", repositoryOwner,
-            repositoryName, pullRequestNumber, getRequestParams(page, perPage));
-        List<Comment> maybeResult = cache.get(query);
-        if (maybeResult != null) {
-            return maybeResult;
-        }
+        String query = String.format("/repos/%s/%s/pulls/%s/comments?%s",
+            request.getRepositoryOwner(),
+            request.getRepositoryName(),
+            request.getPullRequestNumber(),
+            getRequestParams(request.getPage(), request.getPerPage())
+        );
 
         try {
-            logger.info(" - Fetching comments from pull request: " + pullRequestNumber);
+            logger.info(
+                " - Fetching comments from pull request: " + request.getPullRequestNumber());
             List<Comment> result = this.webClientConfiguration.getWebClient().get()
                 .uri(query)
                 .retrieve()

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/ReviewGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/ReviewGitHubRepository.java
@@ -3,39 +3,51 @@ package io.pakland.mdas.githubstats.infrastructure.github.repository;
 import io.pakland.mdas.githubstats.application.exceptions.HttpException;
 import io.pakland.mdas.githubstats.application.mappers.ReviewMapper;
 import io.pakland.mdas.githubstats.domain.entity.UserReview;
+import io.pakland.mdas.githubstats.domain.lib.InternalCaching;
 import io.pakland.mdas.githubstats.domain.repository.ReviewExternalRepository;
 import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubReviewDTO;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import java.util.List;
-
 public class ReviewGitHubRepository implements ReviewExternalRepository {
+
     private final WebClientConfiguration webClientConfiguration;
     private final Logger logger = LoggerFactory.getLogger(ReviewGitHubRepository.class);
+
+    private final InternalCaching<String, List<UserReview>> cache = new InternalCaching<>();
 
     public ReviewGitHubRepository(WebClientConfiguration webClientConfiguration) {
         this.webClientConfiguration = webClientConfiguration;
     }
 
     @Override
-    public List<UserReview> fetchReviewsFromPullRequest(FetchReviewsFromPullRequestRequest request) throws HttpException {
+    public List<UserReview> fetchReviewsFromPullRequest(FetchReviewsFromPullRequestRequest request)
+        throws HttpException {
+        String query = String.format("/repos/%s/%s/pulls/%s/reviews?%s",
+            request.getRepositoryOwner(),
+            request.getRepositoryName(),
+            request.getPullRequestNumber(),
+            getRequestParams(request.getPage(), request.getPerPage())
+        );
+        List<UserReview> maybeResult = cache.get(query);
+        if (maybeResult != null) {
+            return maybeResult;
+        }
+
         try {
 
-            return this.webClientConfiguration.getWebClient().get()
-                    .uri(String.format("/repos/%s/%s/pulls/%s/reviews?%s",
-                            request.getRepositoryOwner(),
-                            request.getRepositoryName(),
-                            request.getPullRequestNumber(),
-                            getRequestParams(request.getPage(), request.getPerPage())
-                    ))
-                    .retrieve()
-                    .bodyToFlux(GitHubReviewDTO.class)
-                    .map(ReviewMapper::dtoToEntity)
-                    .collectList()
-                    .block();
+            List<UserReview> result = this.webClientConfiguration.getWebClient().get()
+                .uri(query)
+                .retrieve()
+                .bodyToFlux(GitHubReviewDTO.class)
+                .map(ReviewMapper::dtoToEntity)
+                .collectList()
+                .block();
+            cache.add(query, result);
 
+            return result;
         } catch (WebClientResponseException ex) {
             logger.error(ex.toString());
             throw new HttpException(ex.getRawStatusCode(), ex.getMessage());

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/ReviewGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/ReviewGitHubRepository.java
@@ -1,0 +1,48 @@
+package io.pakland.mdas.githubstats.infrastructure.github.repository;
+
+import io.pakland.mdas.githubstats.application.exceptions.HttpException;
+import io.pakland.mdas.githubstats.application.mappers.ReviewMapper;
+import io.pakland.mdas.githubstats.domain.entity.UserReview;
+import io.pakland.mdas.githubstats.domain.repository.ReviewExternalRepository;
+import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubReviewDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+
+public class ReviewGitHubRepository implements ReviewExternalRepository {
+    private final WebClientConfiguration webClientConfiguration;
+    private final Logger logger = LoggerFactory.getLogger(ReviewGitHubRepository.class);
+
+    public ReviewGitHubRepository(WebClientConfiguration webClientConfiguration) {
+        this.webClientConfiguration = webClientConfiguration;
+    }
+
+    @Override
+    public List<UserReview> fetchReviewsFromPullRequest(FetchReviewsFromPullRequestRequest request) throws HttpException {
+        try {
+
+            return this.webClientConfiguration.getWebClient().get()
+                    .uri(String.format("/repos/%s/%s/pulls/%s/reviews?%s",
+                            request.getRepositoryOwner(),
+                            request.getRepositoryName(),
+                            request.getPullRequestNumber(),
+                            getRequestParams(request.getPage(), request.getPerPage())
+                    ))
+                    .retrieve()
+                    .bodyToFlux(GitHubReviewDTO.class)
+                    .map(ReviewMapper::dtoToEntity)
+                    .collectList()
+                    .block();
+
+        } catch (WebClientResponseException ex) {
+            logger.error(ex.toString());
+            throw new HttpException(ex.getRawStatusCode(), ex.getMessage());
+        }
+    }
+
+    private String getRequestParams(Integer page, Integer perPage) {
+        return String.format("per_page=%d&page=%d", perPage, page < 0 ? 1 : page);
+    }
+}


### PR DESCRIPTION
- Given a pull request, fetch all of its reviews.
- For the moment i'm only mapping the "id" of the review. We should analyze how we want to fetch also the user it belongs to and its team to compute the reviews inside/outside the team metrics.
- Small refactor to the comment use case to call the repository with a dto request object

Closes #152  