### PR TITLE
[PROPOSAL] feat: alternative to `Review`s per user

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/internal/AggregateReviews.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/internal/AggregateReviews.java
@@ -17,7 +17,7 @@ public class AggregateReviews {
     ReviewAggregation reviewAggregation = new ReviewAggregation();
     public AggregateReviews() {}
 
-    public Map<User, Map<Team, ReviewAggregation>> execute(List<Review> reviews) {
+    public Map<Team, Map<User, ReviewAggregation>> execute(List<Review> reviews) {
         // {
         //   "userA": {
         //      "teamA": [reviewsFromUserAInTeamA],
@@ -26,11 +26,9 @@ public class AggregateReviews {
         //   "userB": { "teamA": [reviewsFromUserBInTeamA] },
         //   "userC": { "teamB": [reviewsFromUserCInTeamB] } ...
         // }
-        Map<User, Map<Team, List<Review>>> groupedReviews = reviews.stream().collect(
-            Collectors.groupingBy(Review::getUser,
-            Collectors.groupingBy(review ->
-                review.getPullRequest().getRepository().getTeam()
-            )));
+        Map<Team, Map<User, List<Review>>> groupedReviews = reviews.stream().collect(
+            Collectors.groupingBy(review -> review.getUser().getTeam(),
+            Collectors.groupingBy(Review::getUser)));
 
         // {
         //   "userA": {
@@ -40,14 +38,14 @@ public class AggregateReviews {
         //   "userB": { "teamA": reviewAggregationUserBTeamA },
         //   "userC": { "teamB": reviewAggregationUserCTeamB } ...
         // }
-        Map<User, Map<Team, ReviewAggregation>> aggReviews = new HashMap<>();
-        groupedReviews.keySet().forEach(user -> {
-            Map<Team, ReviewAggregation> aggReviewsByUser = new HashMap<>();
-            groupedReviews.get(user).keySet().forEach(team -> {
-                List<Review> reviewsByUserByTeam = groupedReviews.get(user).get(team);
-                aggReviewsByUser.put(team, reviewAggregation.aggregate(reviewsByUserByTeam));
+        Map<Team, Map<User, ReviewAggregation>> aggReviews = new HashMap<>();
+        groupedReviews.keySet().forEach(team -> {
+            Map<User, ReviewAggregation> aggReviewsByUser = new HashMap<>();
+            groupedReviews.get(team).keySet().forEach(user -> {
+                List<Review> reviewsByUserByTeam = groupedReviews.get(team).get(user);
+                aggReviewsByUser.put(user, reviewAggregation.aggregate(reviewsByUserByTeam));
             });
-            aggReviews.put(user, aggReviewsByUser);
+            aggReviews.put(team, aggReviewsByUser);
         });
 
         return aggReviews;

--- a/src/main/java/io/pakland/mdas/githubstats/application/internal/AggregateReviews.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/internal/AggregateReviews.java
@@ -1,21 +1,19 @@
 package io.pakland.mdas.githubstats.application.internal;
 
-import io.pakland.mdas.githubstats.domain.entity.Review;
-import io.pakland.mdas.githubstats.domain.entity.ReviewAggregation;
-import io.pakland.mdas.githubstats.domain.entity.Team;
-import io.pakland.mdas.githubstats.domain.entity.User;
-import org.springframework.stereotype.Service;
-
+import io.pakland.mdas.githubstats.domain.entity.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
 
 @Service
 public class AggregateReviews {
 
     ReviewAggregation reviewAggregation = new ReviewAggregation();
-    public AggregateReviews() {}
+
+    public AggregateReviews() {
+    }
 
     public Map<Team, Map<User, ReviewAggregation>> execute(List<Review> reviews) {
         // {
@@ -28,7 +26,7 @@ public class AggregateReviews {
         // }
         Map<Team, Map<User, List<Review>>> groupedReviews = reviews.stream().collect(
             Collectors.groupingBy(review -> review.getUser().getTeam(),
-            Collectors.groupingBy(Review::getUser)));
+                Collectors.groupingBy(Review::getUser)));
 
         // {
         //   "userA": {
@@ -39,12 +37,11 @@ public class AggregateReviews {
         //   "userC": { "teamB": reviewAggregationUserCTeamB } ...
         // }
         Map<Team, Map<User, ReviewAggregation>> aggReviews = new HashMap<>();
-        groupedReviews.keySet().forEach(team -> {
+        groupedReviews.forEach((team, userReviewMap) -> {
             Map<User, ReviewAggregation> aggReviewsByUser = new HashMap<>();
-            groupedReviews.get(team).keySet().forEach(user -> {
-                List<Review> reviewsByUserByTeam = groupedReviews.get(team).get(user);
-                aggReviewsByUser.put(user, reviewAggregation.aggregate(reviewsByUserByTeam));
-            });
+            userReviewMap.forEach((user, reviewList) ->
+                aggReviewsByUser.put(user, reviewAggregation.aggregate(reviewList))
+            );
             aggReviews.put(team, aggReviewsByUser);
         });
 


### PR DESCRIPTION
### Description

This is a proposal to #168 in which we keep the structure of `Organization` -> `Team` -> `User`.

> I also changed the way we work with maps. Instead of using the `getKey()` method and then having to access the value of the key through the `get()` method, we simply use the `entrySet()` method which allows us to access at the `key` and `value` at the same time.