### PR TITLE
Feat: export array of `Metric` to csv file

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/internal/MetricCsvExporter.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/internal/MetricCsvExporter.java
@@ -1,0 +1,52 @@
+package io.pakland.mdas.githubstats.application.internal;
+
+import io.pakland.mdas.githubstats.domain.entity.Metric;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class MetricCsvExporter implements MetricExporter {
+    @Override
+    public void export(List<Metric> metrics, String filePath) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("id")
+            .append(",").append("organization")
+            .append(",").append("team_slug")
+            .append(",").append("user_name")
+            .append(",").append("merged_pulls")
+            .append(",").append("internal_reviews")
+            .append(",").append("external_reviews")
+            .append(",").append("comments_avg_length")
+            .append(",").append("commits_count")
+            .append(",").append("lines_added")
+            .append(",").append("lines_removed")
+            .append(",").append("from")
+            .append(",").append("to")
+            .append("\n");
+
+        for (Metric metric : metrics) {
+            sb.append(metric.getId())
+                .append(",").append(metric.getOrganization())
+                .append(",").append(metric.getTeamSlug())
+                .append(",").append(metric.getUserName())
+                .append(",").append(metric.getMergedPulls().toString())
+                .append(",").append(metric.getInternalReviews().toString())
+                .append(",").append(metric.getExternalReviews().toString())
+                .append(",").append(metric.getCommentsAvgLength().toString())
+                .append(",").append(metric.getCommitsCount().toString())
+                .append(",").append(metric.getLinesAdded().toString())
+                .append(",").append(metric.getLinesRemoved().toString())
+                .append(",").append(metric.getFrom().toString())
+                .append(",").append(metric.getTo().toString())
+                .append("\n");
+        }
+
+        try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(filePath))) {
+            writer.write(sb.toString());
+        }
+
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/internal/MetricCsvExporter.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/internal/MetricCsvExporter.java
@@ -6,47 +6,38 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class MetricCsvExporter implements MetricExporter {
+
     @Override
     public void export(List<Metric> metrics, String filePath) throws IOException {
         StringBuilder sb = new StringBuilder();
-        sb.append("id")
-            .append(",").append("organization")
-            .append(",").append("team_slug")
-            .append(",").append("user_name")
-            .append(",").append("merged_pulls")
-            .append(",").append("internal_reviews")
-            .append(",").append("external_reviews")
-            .append(",").append("comments_avg_length")
-            .append(",").append("commits_count")
-            .append(",").append("lines_added")
-            .append(",").append("lines_removed")
-            .append(",").append("from")
-            .append(",").append("to")
-            .append("\n");
+        ArrayList<String> headerFields = new ArrayList<>(Arrays.asList(
+            "id", "organization", "team_slug", "user_name", "merged_pulls",
+            "internal_reviews", "external_reviews", "comments_avg_length",
+            "commits_count", "lines_added", "lines_removed", "from", "to"));
 
-        for (Metric metric : metrics) {
-            sb.append(metric.getId())
-                .append(",").append(metric.getOrganization())
-                .append(",").append(metric.getTeamSlug())
-                .append(",").append(metric.getUserName())
-                .append(",").append(metric.getMergedPulls().toString())
-                .append(",").append(metric.getInternalReviews().toString())
-                .append(",").append(metric.getExternalReviews().toString())
-                .append(",").append(metric.getCommentsAvgLength().toString())
-                .append(",").append(metric.getCommitsCount().toString())
-                .append(",").append(metric.getLinesAdded().toString())
-                .append(",").append(metric.getLinesRemoved().toString())
-                .append(",").append(metric.getFrom().toString())
-                .append(",").append(metric.getTo().toString())
-                .append("\n");
-        }
+        sb.append(this.appendStringArrayList(headerFields));
+        metrics.forEach(metric ->
+            sb.append(this.appendStringArrayList(metric.getValuesAsStringArrayList())));
 
         try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(filePath))) {
             writer.write(sb.toString());
         }
+    }
 
+    private String appendStringArrayList(ArrayList<String> fields) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < fields.size(); i++) {
+            sb.append(fields.get(i));
+            if (i < fields.size() - 1) {
+                sb.append(",");
+            }
+        }
+        sb.append("\n");
+        return sb.toString();
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/internal/MetricExporter.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/internal/MetricExporter.java
@@ -1,0 +1,10 @@
+package io.pakland.mdas.githubstats.application.internal;
+
+import io.pakland.mdas.githubstats.domain.entity.Metric;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface MetricExporter {
+    void export(List<Metric> metrics, String filePath) throws IOException;
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/CSVExportable.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/CSVExportable.java
@@ -1,7 +1,0 @@
-package io.pakland.mdas.githubstats.domain.entity;
-
-public interface CSVExportable {
-
-    String toCSV();
-
-}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/entity/Metric.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/entity/Metric.java
@@ -1,15 +1,22 @@
 package io.pakland.mdas.githubstats.domain.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.NaturalId;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 @Entity
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Table(name = "metric")
 public class Metric {
 
@@ -22,31 +29,31 @@ public class Metric {
     private String organization;
 
     @NaturalId
-    @Column(name="team_slug", nullable = false)
+    @Column(name = "team_slug", nullable = false)
     private String teamSlug;
 
-    @Column(name="user_name", nullable = false)
+    @Column(name = "user_name", nullable = false)
     private String userName;
 
-    @Column(name="merged_pulls", nullable = false)
+    @Column(name = "merged_pulls", nullable = false)
     private Integer mergedPulls;
 
-    @Column(name="internal_reviews", nullable = false)
+    @Column(name = "internal_reviews", nullable = false)
     private Integer internalReviews;
 
-    @Column(name="external_reviews", nullable = false)
+    @Column(name = "external_reviews", nullable = false)
     private Integer externalReviews;
 
-    @Column(name="comments_avg_length", nullable = false)
+    @Column(name = "comments_avg_length", nullable = false)
     private Integer commentsAvgLength;
 
-    @Column(name="commits_count", nullable = false)
+    @Column(name = "commits_count", nullable = false)
     private Integer commitsCount;
 
-    @Column(name="lines_added", nullable = false)
+    @Column(name = "lines_added", nullable = false)
     private Integer linesAdded;
 
-    @Column(name="lines_removed", nullable = false)
+    @Column(name = "lines_removed", nullable = false)
     private Integer linesRemoved;
 
     @Column(nullable = false)
@@ -65,5 +72,14 @@ public class Metric {
     @Override
     public int hashCode() {
         return getClass().hashCode();
+    }
+
+    public ArrayList<String> getValuesAsStringArrayList() {
+        return new ArrayList<>(Arrays.asList(
+            Integer.toString(id), organization, teamSlug, userName,
+            Integer.toString(mergedPulls), Integer.toString(internalReviews), Integer.toString(externalReviews),
+            Integer.toString(commentsAvgLength), Integer.toString(commitsCount), Integer.toString(linesAdded),
+            Integer.toString(linesRemoved), from.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")), to.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+        ));
     }
 }


### PR DESCRIPTION
Export Metriics to a certain format. In this case is CSV. The `MetricCsvExporter::export` method will export an array of metric objects to a .csv file into the filesystem on the defined path. We must declare the resulting file name in the defined path (this is subject to change if we decide we want to set a default file name).
Closes #170 