### PR TITLE
feat: apply user options to controller

### DIFF
--- a/src/main/java/io/pakland/mdas/githubstats/application/AggregateComments.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/AggregateComments.java
@@ -1,0 +1,43 @@
+package io.pakland.mdas.githubstats.application;
+
+import io.pakland.mdas.githubstats.domain.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AggregateComments {
+
+    public AggregateComments() {
+    }
+
+    private static Map<Team, Map<User, List<Comment>>> groupUserCommentsByTeam(
+        List<Comment> comments) {
+        return comments
+            .stream()
+            .collect(
+                Collectors.groupingBy(comment -> comment.getUser().getTeam(),
+                    Collectors.groupingBy(Comment::getUser)));
+    }
+
+    private static Map<User, CommentAggregation> groupCommentAggregationsByUser(
+        Map<User, List<Comment>> userReviewMap) {
+        Map<User, CommentAggregation> aggCommentByUser = new HashMap<>();
+        userReviewMap.forEach((user, commentList) ->
+            aggCommentByUser.put(user, CommentAggregation.aggregate(commentList))
+        );
+        return aggCommentByUser;
+    }
+
+    public Map<Team, Map<User, CommentAggregation>> execute(List<Comment> comments) {
+        Map<Team, Map<User, List<Comment>>> groupedComments = groupUserCommentsByTeam(comments);
+
+        Map<Team, Map<User, CommentAggregation>> aggComments = new HashMap<>();
+        groupedComments.forEach((team, userCommentMap) ->
+            aggComments.put(team, groupCommentAggregationsByUser(userCommentMap)));
+
+        return aggComments;
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/application/AggregateComments.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/AggregateComments.java
@@ -18,7 +18,7 @@ public class AggregateComments {
         return comments
             .stream()
             .collect(
-                Collectors.groupingBy(comment -> comment.getUser().getTeam(),
+                Collectors.groupingBy(comment -> comment.getPullRequest().getRepository().getTeam(),
                     Collectors.groupingBy(Comment::getUser)));
     }
 

--- a/src/main/java/io/pakland/mdas/githubstats/application/AggregatePullRequests.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/AggregatePullRequests.java
@@ -1,51 +1,43 @@
 package io.pakland.mdas.githubstats.application;
 
-import io.pakland.mdas.githubstats.domain.PullRequest;
-import io.pakland.mdas.githubstats.domain.PullRequestAggregation;
-import io.pakland.mdas.githubstats.domain.Team;
-import io.pakland.mdas.githubstats.domain.User;
-
+import io.pakland.mdas.githubstats.domain.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class AggregatePullRequests {
+
     PullRequestAggregation pullRequestAggregation = new PullRequestAggregation();
 
     public AggregatePullRequests() {
     }
 
-    public Map<Team, Map<User, PullRequestAggregation>> execute(List<PullRequest> pullRequests) {
-        // {
-        //   "userA": {
-        //      "teamA": [prsFromUserAInTeamA],
-        //      "teamB": [prsFromUserAInTeamB]
-        //   },
-        //   "userB": { "teamA": [prsFromUserBInTeamA] },
-        //   "userC": { "teamB": [prsFromUserCInTeamB] } ...
-        // }
-        Map<Team, Map<User, List<PullRequest>>> groupedPullRequests = pullRequests.stream().collect(
+    private static Map<Team, Map<User, List<PullRequest>>> groupPullRequestsByTeam(
+        List<PullRequest> pullRequests) {
+        return pullRequests.stream().collect(
             Collectors.groupingBy(pr -> pr.getRepository().getTeam(),
                 Collectors.groupingBy(PullRequest::getUser)));
+    }
 
-        // {
-        //   "userA": {
-        //      "teamA": prAggregationUserATeamA
-        //      "teamB": prAggregationUserATeamB
-        //   },
-        //   "userB": { "teamA": prAggregationUserBTeamA },
-        //   "userC": { "teamB": prAggregationUserCTeamB } ...
-        // }
+    public Map<Team, Map<User, PullRequestAggregation>> execute(List<PullRequest> pullRequests) {
+        Map<Team, Map<User, List<PullRequest>>> groupedPullRequests = groupPullRequestsByTeam(
+            pullRequests);
+
         Map<Team, Map<User, PullRequestAggregation>> aggPullRequests = new HashMap<>();
-        groupedPullRequests.forEach((team, userPrMap) -> {
-            Map<User, PullRequestAggregation> aggPullRequestsByUser = new HashMap<>();
-            userPrMap.forEach((user, prList) -> aggPullRequestsByUser.put(user,
-                pullRequestAggregation.aggregate(prList)));
-            aggPullRequests.put(team, aggPullRequestsByUser);
-        });
+        groupedPullRequests.forEach((team, userPrMap) -> aggPullRequests.put(team,
+            groupPullRequestAggregationsByUser(userPrMap))
+        );
 
         return aggPullRequests;
+    }
+
+    private Map<User, PullRequestAggregation> groupPullRequestAggregationsByUser(
+        Map<User, List<PullRequest>> userPrMap) {
+        Map<User, PullRequestAggregation> aggPullRequestsByUser = new HashMap<>();
+        userPrMap.forEach((user, prList) -> aggPullRequestsByUser.put(user,
+            pullRequestAggregation.aggregate(prList)));
+        return aggPullRequestsByUser;
     }
 
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/AggregateReviews.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/AggregateReviews.java
@@ -1,53 +1,41 @@
 package io.pakland.mdas.githubstats.application;
 
-import io.pakland.mdas.githubstats.domain.Review;
-import io.pakland.mdas.githubstats.domain.ReviewAggregation;
-import io.pakland.mdas.githubstats.domain.Team;
-import io.pakland.mdas.githubstats.domain.User;
-import org.springframework.stereotype.Service;
-
+import io.pakland.mdas.githubstats.domain.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
 
 @Service
 public class AggregateReviews {
 
-    ReviewAggregation reviewAggregation = new ReviewAggregation();
-
     public AggregateReviews() {
     }
 
-    public Map<Team, Map<User, ReviewAggregation>> execute(List<Review> reviews) {
-        // {
-        //   "userA": {
-        //      "teamA": [reviewsFromUserAInTeamA],
-        //      "teamB": [reviewsFromUserAInTeamB]
-        //   },
-        //   "userB": { "teamA": [reviewsFromUserBInTeamA] },
-        //   "userC": { "teamB": [reviewsFromUserCInTeamB] } ...
-        // }
-        Map<Team, Map<User, List<Review>>> groupedReviews = reviews.stream().collect(
-            Collectors.groupingBy(review -> review.getUser().getTeam(),
-                Collectors.groupingBy(Review::getUser)));
+    private static Map<Team, Map<User, List<Review>>> groupUserReviewsByTeam(List<Review> reviews) {
+        return reviews
+            .stream()
+            .collect(
+                Collectors.groupingBy(review -> review.getUser().getTeam(),
+                    Collectors.groupingBy(Review::getUser)));
+    }
 
-        // {
-        //   "userA": {
-        //      "teamA": reviewAggregationUserATeamA
-        //      "teamB": reviewAggregationUserATeamB
-        //   },
-        //   "userB": { "teamA": reviewAggregationUserBTeamA },
-        //   "userC": { "teamB": reviewAggregationUserCTeamB } ...
-        // }
+    private static Map<User, ReviewAggregation> groupReviewAggregationsByUser(
+        Map<User, List<Review>> userReviewMap) {
+        Map<User, ReviewAggregation> aggReviewsByUser = new HashMap<>();
+        userReviewMap.forEach((user, reviewList) ->
+            aggReviewsByUser.put(user, ReviewAggregation.aggregate(reviewList))
+        );
+        return aggReviewsByUser;
+    }
+
+    public Map<Team, Map<User, ReviewAggregation>> execute(List<Review> reviews) {
+        Map<Team, Map<User, List<Review>>> groupedReviews = groupUserReviewsByTeam(reviews);
+
         Map<Team, Map<User, ReviewAggregation>> aggReviews = new HashMap<>();
-        groupedReviews.forEach((team, userReviewMap) -> {
-            Map<User, ReviewAggregation> aggReviewsByUser = new HashMap<>();
-            userReviewMap.forEach((user, reviewList) ->
-                aggReviewsByUser.put(user, reviewAggregation.aggregate(reviewList))
-            );
-            aggReviews.put(team, aggReviewsByUser);
-        });
+        groupedReviews.forEach((team, userReviewMap) ->
+            aggReviews.put(team, groupReviewAggregationsByUser(userReviewMap)));
 
         return aggReviews;
     }

--- a/src/main/java/io/pakland/mdas/githubstats/application/FetchCommentsFromPullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/FetchCommentsFromPullRequest.java
@@ -5,7 +5,6 @@ import io.pakland.mdas.githubstats.domain.Comment;
 import io.pakland.mdas.githubstats.domain.DateRange;
 import io.pakland.mdas.githubstats.domain.PullRequest;
 import io.pakland.mdas.githubstats.domain.repository.CommentExternalRepository;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,6 +62,7 @@ public class FetchCommentsFromPullRequest {
             responseResults = apiResults.size();
             page++;
         } while (responseResults > 0);
+        commentList.parallelStream().forEach(comment -> comment.setPullRequest(pullRequest));
 
         return commentList;
     }

--- a/src/main/java/io/pakland/mdas/githubstats/application/FetchReviewsFromPullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/FetchReviewsFromPullRequest.java
@@ -61,6 +61,7 @@ public class FetchReviewsFromPullRequest {
             responseResults = apiResults.size();
             page++;
         } while (responseResults != 100);
+        reviewList.parallelStream().forEach(review -> review.setPullRequest(pullRequest));
 
         return reviewList;
     }

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/CommentDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/CommentDTO.java
@@ -7,5 +7,7 @@ public interface CommentDTO {
 
     String getBody();
 
+    UserDTO getUser();
+
     Date getCreatedAt();
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/dto/ReviewDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/dto/ReviewDTO.java
@@ -6,7 +6,11 @@ public interface ReviewDTO {
 
     Integer getId();
 
+    String getBody();
+
     UserDTO getUser();
 
     Date getSubmittedAt();
+
+    boolean getReviewFromInternalAuthor();
 }

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/CommentMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/CommentMapper.java
@@ -9,6 +9,7 @@ public class CommentMapper {
         return Comment.builder()
             .id(dto.getId())
             .body(dto.getBody())
+            .user(UserMapper.dtoToEntity(dto.getUser()))
             .createdAt(dto.getCreatedAt())
             .build();
     }

--- a/src/main/java/io/pakland/mdas/githubstats/application/mappers/ReviewMapper.java
+++ b/src/main/java/io/pakland/mdas/githubstats/application/mappers/ReviewMapper.java
@@ -8,7 +8,9 @@ public class ReviewMapper {
     public static Review dtoToEntity(ReviewDTO dto) {
         return Review.builder()
             .id(dto.getId())
+            .body(dto.getBody())
             .user(UserMapper.dtoToEntity(dto.getUser()))
+            .isReviewFromInternalAuthor(dto.getReviewFromInternalAuthor())
             .submittedAt(dto.getSubmittedAt())
             .build();
     }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Comment.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Comment.java
@@ -15,13 +15,11 @@ public class Comment {
 
     private Integer id;
 
-    private Review review;
+    private User user;
 
     private String body;
 
     private Date createdAt;
 
-    public Integer getLength() {
-        return this.body.length();
-    }
+    private PullRequest pullRequest;
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Comment.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Comment.java
@@ -1,11 +1,7 @@
 package io.pakland.mdas.githubstats.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.Date;
+import lombok.*;
 
 @Data
 @NoArgsConstructor
@@ -22,4 +18,8 @@ public class Comment {
     private Date createdAt;
 
     private PullRequest pullRequest;
+
+    public boolean isAuthorNamed(String name) {
+        return this.user.isNamed(name);
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Comment.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Comment.java
@@ -6,6 +6,7 @@ import lombok.*;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 @Builder
 public class Comment {
 
@@ -17,6 +18,7 @@ public class Comment {
 
     private Date createdAt;
 
+    @ToString.Exclude
     private PullRequest pullRequest;
 
     public boolean isAuthorNamed(String name) {

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Comment.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Comment.java
@@ -22,4 +22,8 @@ public class Comment {
     public boolean isAuthorNamed(String name) {
         return this.user.isNamed(name);
     }
+
+    public int bodySize() {
+        return this.body.length();
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/CommentAggregation.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/CommentAggregation.java
@@ -1,0 +1,27 @@
+package io.pakland.mdas.githubstats.domain;
+
+import java.util.List;
+
+public class CommentAggregation {
+
+    private int bodyLength;
+    private int commentCount;
+
+    private CommentAggregation() {
+        this.bodyLength = 0;
+        this.commentCount = 0;
+    }
+
+    public static CommentAggregation aggregate(List<Comment> comments) {
+        CommentAggregation aggregation = new CommentAggregation();
+        comments.forEach(comment -> {
+            aggregation.bodyLength += comment.bodySize();
+            aggregation.commentCount++;
+        });
+        return aggregation;
+    }
+
+    public int averageBodyLength() {
+        return bodyLength / commentCount;
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/domain/HistoricQueries.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/HistoricQueries.java
@@ -19,7 +19,7 @@ public class HistoricQueries {
 
     @Column(name = "entity_type", nullable = false)
     @Enumerated(EnumType.STRING)
-    private EntityType entityType;
+    private OptionType entityType;
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/io/pakland/mdas/githubstats/domain/OptionType.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/OptionType.java
@@ -1,6 +1,6 @@
 package io.pakland.mdas.githubstats.domain;
 
-public enum EntityType {
+public enum OptionType {
     ORGANIZATION,
     TEAM,
     USER

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Organization.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Organization.java
@@ -32,8 +32,8 @@ public class Organization {
         team.setOrganization(this);
     }
 
-    public List<Team> getTeams() {
-        return teams.stream().toList();
+    public boolean isNamed(String name) {
+        return this.login.equals(name);
     }
 
     @Override

--- a/src/main/java/io/pakland/mdas/githubstats/domain/PullRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/PullRequest.java
@@ -32,6 +32,4 @@ public class PullRequest {
     private Repository repository;
 
     private User user;
-
-    private List<Review> reviews = new ArrayList<>();
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Review.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Review.java
@@ -17,25 +17,24 @@ public class Review {
 
     private Integer id;
 
+    private String body;
+
     private User user;
 
     private Date submittedAt;
 
     private PullRequest pullRequest;
 
-    private List<Comment> comments = new ArrayList<>();
-
-    public int sumCommentLength() {
-        return comments.stream().mapToInt(Comment::getLength).sum();
-    }
+    // This value allows us to know if the author of the review is part of the team that
+    // owns the repository
+    private boolean isReviewFromInternalAuthor;
 
     public boolean isInternal() {
-        return getPullRequest().getRepository().getTeam()
-            .equals(getUser().getTeam());
+        return this.isReviewFromInternalAuthor;
     }
 
-    public boolean isReviewFromTeam(Team team) {
-        return pullRequest.getRepository().getTeam().equals(team);
+    public boolean isAuthorNamed(String name) {
+        return user.isNamed(name);
     }
 
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Review.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Review.java
@@ -33,6 +33,10 @@ public class Review {
         return this.isReviewFromInternalAuthor;
     }
 
+    public int bodySize() {
+        return this.body.length();
+    }
+
     public boolean isAuthorNamed(String name) {
         return user.isNamed(name);
     }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/ReviewAggregation.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/ReviewAggregation.java
@@ -4,55 +4,31 @@ import java.util.List;
 
 public class ReviewAggregation {
 
-    private int internalCommentLengthSum = 0;
-    private int externalCommentLengthSum = 0;
-    private int internalCommentCount = 0;
-    private int externalCommentCount = 0;
+    private int bodyLength;
+    private int internalReviewCount;
+    private int externalReviewCount;
 
-    public ReviewAggregation aggregate(List<Review> reviews) {
-        resetMetrics();
-
-        return this;
+    private ReviewAggregation() {
+        this.bodyLength = 0;
+        this.internalReviewCount = 0;
+        this.externalReviewCount = 0;
     }
 
-    private void resetMetrics() {
-        internalCommentLengthSum = 0;
-        externalCommentLengthSum = 0;
-        internalCommentCount = 0;
-        externalCommentCount = 0;
+    public static ReviewAggregation aggregate(List<Review> reviews) {
+        ReviewAggregation aggregation = new ReviewAggregation();
+        reviews.forEach(review -> {
+            if (review.isInternal()) {
+                aggregation.internalReviewCount++;
+            } else {
+                aggregation.externalReviewCount++;
+            }
+
+            aggregation.bodyLength += review.bodySize();
+        });
+        return aggregation;
     }
 
-    public float getInternalCommentLengthAvg() {
-        if (internalCommentCount == 0) return 0;
-        return (float) internalCommentLengthSum / internalCommentCount;
+    public int averageBodyLength() {
+        return bodyLength / (internalReviewCount + externalReviewCount);
     }
-
-    public float getExternalCommentLengthAvg() {
-        if (externalCommentCount == 0) return 0;
-        return (float) externalCommentLengthSum / externalCommentCount;
-    }
-
-    public float getTotalCommentLengthAvg() {
-        if (internalCommentCount + externalCommentCount == 0) return 0;
-        return (float)
-            (internalCommentLengthSum + externalCommentLengthSum) /
-            (internalCommentCount + externalCommentCount);
-    }
-
-    public int getInternalCommentLengthSum() {
-        return internalCommentLengthSum;
-    }
-
-    public int getExternalCommentLengthSum() {
-        return externalCommentLengthSum;
-    }
-
-    public int getInternalCommentCount() {
-        return internalCommentCount;
-    }
-
-    public int getExternalCommentCount() {
-        return externalCommentCount;
-    }
-
 }

--- a/src/main/java/io/pakland/mdas/githubstats/domain/ReviewAggregation.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/ReviewAggregation.java
@@ -12,16 +12,6 @@ public class ReviewAggregation {
     public ReviewAggregation aggregate(List<Review> reviews) {
         resetMetrics();
 
-        reviews.forEach(userReview -> {
-            if (userReview.isInternal()) {
-                internalCommentLengthSum += userReview.sumCommentLength();
-                internalCommentCount++;
-            } else {
-                externalCommentLengthSum += userReview.sumCommentLength();
-                externalCommentCount++;
-            }
-        });
-
         return this;
     }
 

--- a/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/Team.java
@@ -50,8 +50,8 @@ public class Team {
         repository.setTeam(this);
     }
 
-    public List<Repository> getRepositories() {
-        return repositories.stream().toList();
+    public boolean isNamed(String name) {
+        return this.slug.equals(name);
     }
 
     @Override

--- a/src/main/java/io/pakland/mdas/githubstats/domain/User.java
+++ b/src/main/java/io/pakland/mdas/githubstats/domain/User.java
@@ -19,6 +19,10 @@ public class User {
 
     private Team team;
 
+    public boolean isNamed(String name) {
+        return login.equals(name);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/controller/GitHubController.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/controller/GitHubController.java
@@ -88,16 +88,13 @@ public class GitHubController {
 
             ExecutorService executor = Executors.newFixedThreadPool(3);
             pullRequestList.parallelStream().forEach(pullRequest -> {
+                Future<?> reviewsFuture = executor.submit(
+                    () -> this.fetchReviewsFromPullRequest(pullRequest));
                 Future<?> commentsFuture = executor.submit(
                     () -> this.fetchCommentsFromPullRequest(pullRequest));
 
                 try {
                     commentsFuture.get();
-                    if (true) {
-                        return;
-                    }
-                    Future<?> reviewsFuture = executor.submit(
-                        () -> this.fetchReviewsFromPullRequest(pullRequest));
                     reviewsFuture.get();
                 } catch (InterruptedException | ExecutionException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/controller/GitHubController.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/controller/GitHubController.java
@@ -6,7 +6,6 @@ import io.pakland.mdas.githubstats.domain.*;
 import io.pakland.mdas.githubstats.domain.repository.*;
 import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubOptionRequest;
 import io.pakland.mdas.githubstats.infrastructure.github.repository.*;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
@@ -89,14 +88,17 @@ public class GitHubController {
 
             ExecutorService executor = Executors.newFixedThreadPool(3);
             pullRequestList.parallelStream().forEach(pullRequest -> {
-                Future<?> reviewsFuture = executor.submit(
-                    () -> this.fetchReviewsFromPullRequest(pullRequest));
                 Future<?> commentsFuture = executor.submit(
                     () -> this.fetchCommentsFromPullRequest(pullRequest));
 
                 try {
-                    reviewsFuture.get();
                     commentsFuture.get();
+                    if (true) {
+                        return;
+                    }
+                    Future<?> reviewsFuture = executor.submit(
+                        () -> this.fetchReviewsFromPullRequest(pullRequest));
+                    reviewsFuture.get();
                 } catch (InterruptedException | ExecutionException e) {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/controller/GitHubController.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/controller/GitHubController.java
@@ -115,8 +115,6 @@ public class GitHubController {
             // Fetch Reviews from each Pull Request.
             List<Review> reviewList = new FetchReviewsFromPullRequest(reviewRepository)
                 .execute(pullRequest, getRequestDateRange());
-            LoggerFactory.getLogger(this.getClass()).info(
-                String.format("pr: %s, count: %s", pullRequest.getNumber(), reviewList.size()));
         } catch (HttpException e) {
             throw new RuntimeException(e);
         }
@@ -127,8 +125,6 @@ public class GitHubController {
             // Fetch Comments from each Pull Request.
             List<Comment> commentList = new FetchCommentsFromPullRequest(commentRepository)
                 .execute(pullRequest, getRequestDateRange());
-            LoggerFactory.getLogger(this.getClass()).info(
-                String.format("pr: %s, count: %s", pullRequest.getNumber(), commentList.size()));
         } catch (HttpException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/controller/GitHubMiddleware.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/controller/GitHubMiddleware.java
@@ -1,8 +1,7 @@
 package io.pakland.mdas.githubstats.infrastructure.github.controller;
 
 import io.pakland.mdas.githubstats.infrastructure.controller.Middleware;
-import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubUserOptionRequest;
-
+import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubOptionRequest;
 import io.pakland.mdas.githubstats.infrastructure.shell.model.ShellRequest;
 
 public class GitHubMiddleware extends Middleware {
@@ -14,11 +13,12 @@ public class GitHubMiddleware extends Middleware {
     @Override
     public String execute() {
         GitHubController gitHubController = new GitHubController(
-                GitHubUserOptionRequest.builder()
-                        .userName(super.request.getName())
-                        .apiKey(super.request.getApiKey())
-                        .from(super.request.getFrom())
-                        .to(super.request.getTo()).build());
+            GitHubOptionRequest.builder()
+                .name(super.request.getName())
+                .apiKey(super.request.getApiKey())
+                .type(super.request.getEntityType())
+                .from(super.request.getFrom())
+                .to(super.request.getTo()).build());
         gitHubController.execute();
 
         return "csv from github";

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommentDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubCommentDTO.java
@@ -2,6 +2,7 @@ package io.pakland.mdas.githubstats.infrastructure.github.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.pakland.mdas.githubstats.application.dto.CommentDTO;
+import io.pakland.mdas.githubstats.application.dto.UserDTO;
 import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -17,6 +18,9 @@ public class GitHubCommentDTO implements CommentDTO {
 
     @JsonProperty("body")
     private String body;
+
+    @JsonProperty("user")
+    private GitHubUserDTO user;
 
     @JsonProperty("created_at")
     private Date createdAt;
@@ -35,4 +39,10 @@ public class GitHubCommentDTO implements CommentDTO {
     public Date getCreatedAt() {
         return this.createdAt;
     }
+
+    @Override
+    public UserDTO getUser() {
+        return this.user;
+    }
+
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubOptionRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubOptionRequest.java
@@ -10,9 +10,22 @@ import lombok.Getter;
 @Getter
 @Builder
 public class GitHubOptionRequest {
+
     private String name;
     private String apiKey;
     private OptionType type;
     private Date from;
     private Date to;
+
+    public boolean isOrganizationType() {
+        return type.equals(OptionType.ORGANIZATION);
+    }
+
+    public boolean isTeamType() {
+        return type.equals(OptionType.TEAM);
+    }
+
+    public boolean isUserType() {
+        return type.equals(OptionType.USER);
+    }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubOptionRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubOptionRequest.java
@@ -1,5 +1,6 @@
 package io.pakland.mdas.githubstats.infrastructure.github.model;
 
+import io.pakland.mdas.githubstats.domain.OptionType;
 import java.util.Date;
 import lombok.Builder;
 import lombok.Data;
@@ -8,9 +9,10 @@ import lombok.Getter;
 @Data
 @Getter
 @Builder
-public class GitHubUserOptionRequest {
-    private String userName;
+public class GitHubOptionRequest {
+    private String name;
     private String apiKey;
+    private OptionType type;
     private Date from;
     private Date to;
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubReviewDTO.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/model/GitHubReviewDTO.java
@@ -16,8 +16,14 @@ public class GitHubReviewDTO implements ReviewDTO {
     @JsonProperty("id")
     private Integer id;
 
+    @JsonProperty("body")
+    private String body;
+
     @JsonProperty("user")
     private GitHubUserDTO user;
+
+    @JsonProperty("author_association")
+    private String authorAssociation;
 
     @JsonProperty("submitted_at")
     private Date submittedAt;
@@ -28,6 +34,11 @@ public class GitHubReviewDTO implements ReviewDTO {
     }
 
     @Override
+    public String getBody() {
+        return this.body;
+    }
+
+    @Override
     public UserDTO getUser() {
         return this.user;
     }
@@ -35,5 +46,13 @@ public class GitHubReviewDTO implements ReviewDTO {
     @Override
     public Date getSubmittedAt() {
         return this.submittedAt;
+    }
+
+    @Override
+    public boolean getReviewFromInternalAuthor() {
+        return switch (this.authorAssociation) {
+            case "MEMBER", "COLLABORATOR", "OWNER" -> true;
+            default -> false;
+        };
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommentGitHubRepository.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/github/repository/CommentGitHubRepository.java
@@ -8,6 +8,7 @@ import io.pakland.mdas.githubstats.domain.repository.CommentExternalRepository;
 import io.pakland.mdas.githubstats.domain.utils.InternalCaching;
 import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubCommentDTO;
 import io.pakland.mdas.githubstats.infrastructure.github.model.GitHubPageableRequest;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -46,6 +47,13 @@ public class CommentGitHubRepository implements CommentExternalRepository {
                 .retrieve()
                 .bodyToFlux(GitHubCommentDTO.class)
                 .parallel()
+                .filter(comment -> {
+                    if (comment.getUser() == null) {
+                        System.out.println(pullRequest.getNumber());
+                    }
+                    return Objects.nonNull(comment.getCreatedAt()) && Objects.nonNull(
+                        comment.getUser());
+                })
                 .map(CommentMapper::dtoToEntity)
                 .sequential()
                 .collectList()

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/postgres/PostgresMiddleware.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/postgres/PostgresMiddleware.java
@@ -1,6 +1,6 @@
 package io.pakland.mdas.githubstats.infrastructure.postgres;
 
-import io.pakland.mdas.githubstats.domain.EntityType;
+import io.pakland.mdas.githubstats.domain.OptionType;
 import io.pakland.mdas.githubstats.infrastructure.controller.Middleware;
 import io.pakland.mdas.githubstats.infrastructure.shell.model.ShellRequest;
 
@@ -12,7 +12,7 @@ public class PostgresMiddleware extends Middleware {
 
     @Override
     public String execute() {
-        if (super.request.getEntityType().equals(EntityType.USER) &&
+        if (super.request.getEntityType().equals(OptionType.USER) &&
             super.request.getName().equals("plozanol")) {
             return "csv from db";
         }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/components/ShellComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/components/ShellComponent.java
@@ -1,0 +1,63 @@
+package io.pakland.mdas.githubstats.infrastructure.shell.components;
+
+
+import io.pakland.mdas.githubstats.domain.OptionType;
+import io.pakland.mdas.githubstats.infrastructure.controller.MainController;
+import io.pakland.mdas.githubstats.infrastructure.shell.model.ShellRequest;
+import io.pakland.mdas.githubstats.infrastructure.shell.validation.DateValidator;
+import io.pakland.mdas.githubstats.infrastructure.shell.validation.UserNameValidator;
+import org.springframework.shell.standard.ShellOption;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+@org.springframework.shell.standard.ShellComponent
+public abstract class ShellComponent {
+
+    private final OptionType optionType;
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    protected ShellComponent(OptionType optionType) {
+       this.optionType = optionType;
+    }
+
+    private boolean run(
+        @ShellOption(value = {"n"}) String userName,
+        @ShellOption(value = {"key"}) String apiKey,
+        @ShellOption(value = {"from"}) String fromDate,
+        @ShellOption(value = {"to"}) String toDate
+    ) {
+        DateValidator dateValidator = new DateValidator();
+        UserNameValidator userNameValidator = new UserNameValidator();
+
+        boolean isInputValid = dateValidator.validate(fromDate)
+            && dateValidator.validate(toDate)
+            && userNameValidator.validate(userName);
+
+        if (!isInputValid) {
+            // Alert user, and halt command
+            return false;
+        }
+
+        ShellRequest shellRequest;
+        try {
+            shellRequest = ShellRequest.builder()
+                .entityType(this.optionType)
+                .name(userName)
+                .apiKey(apiKey)
+                .from(new SimpleDateFormat("dd/MM/yy").parse("01/" + fromDate))
+                .to(new SimpleDateFormat("dd/MM/yy").parse("01/" + toDate))
+                .build();
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+
+        MainController main = new MainController(shellRequest);
+        String serializedOutput = main.execute();
+        System.out.println(serializedOutput);
+
+        // TODO : return console / file / etc.. output
+        return true;
+    }
+
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/components/ShellOrganizationComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/components/ShellOrganizationComponent.java
@@ -1,0 +1,10 @@
+package io.pakland.mdas.githubstats.infrastructure.shell.components;
+
+import io.pakland.mdas.githubstats.domain.OptionType;
+
+public class ShellOrganizationComponent extends ShellComponent {
+
+    public ShellOrganizationComponent() {
+        super(OptionType.ORGANIZATION);
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/components/ShellTeamComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/components/ShellTeamComponent.java
@@ -1,33 +1,10 @@
 package io.pakland.mdas.githubstats.infrastructure.shell.components;
 
-import io.pakland.mdas.githubstats.infrastructure.shell.validation.DateValidator;
-import io.pakland.mdas.githubstats.infrastructure.shell.validation.TeamNameValidator;
-import org.springframework.shell.standard.ShellComponent;
-import org.springframework.shell.standard.ShellOption;
+import io.pakland.mdas.githubstats.domain.OptionType;
 
-@ShellComponent
-public class ShellTeamComponent {
+public class ShellTeamComponent extends ShellComponent {
 
-    private boolean team(
-            @ShellOption(value = {"n"}) String teamName,
-            @ShellOption(value = {"from"}) String fromDate,
-            @ShellOption(value = {"to"}) String toDate
-    ) {
-        DateValidator dateValidator = new DateValidator();
-        TeamNameValidator teamNameValidator = new TeamNameValidator();
-
-        boolean isInputValid = dateValidator.validate(fromDate)
-                && dateValidator.validate(toDate)
-                && teamNameValidator.validate(teamName);
-
-        if (!isInputValid) {
-            // Alert user, and halt command
-            return false;
-        }
-
-        // ... Perform request ...
-
-        return true;
+    public ShellTeamComponent() {
+        super(OptionType.TEAM);
     }
-
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/components/ShellUserComponent.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/components/ShellUserComponent.java
@@ -1,58 +1,10 @@
 package io.pakland.mdas.githubstats.infrastructure.shell.components;
 
+import io.pakland.mdas.githubstats.domain.OptionType;
 
-import io.pakland.mdas.githubstats.domain.EntityType;
-import io.pakland.mdas.githubstats.infrastructure.controller.MainController;
-import io.pakland.mdas.githubstats.infrastructure.shell.model.ShellRequest;
-import io.pakland.mdas.githubstats.infrastructure.shell.validation.DateValidator;
-import io.pakland.mdas.githubstats.infrastructure.shell.validation.UserNameValidator;
-import org.springframework.shell.standard.ShellComponent;
-import org.springframework.shell.standard.ShellOption;
+public class ShellUserComponent extends ShellComponent {
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-
-@ShellComponent
-public class ShellUserComponent {
-
-    private ShellRequest shellRequest;
-
-    private boolean user(
-        @ShellOption(value = {"n"}) String userName,
-        @ShellOption(value = {"key"}) String apiKey,
-        @ShellOption(value = {"from"}) String fromDate,
-        @ShellOption(value = {"to"}) String toDate
-    ) {
-        DateValidator dateValidator = new DateValidator();
-        UserNameValidator userNameValidator = new UserNameValidator();
-
-        boolean isInputValid = dateValidator.validate(fromDate)
-            && dateValidator.validate(toDate)
-            && userNameValidator.validate(userName);
-
-        if (!isInputValid) {
-            // Alert user, and halt command
-            return false;
-        }
-
-        try {
-            this.shellRequest = ShellRequest.builder()
-                .entityType(EntityType.USER)
-                .name(userName)
-                .apiKey(apiKey)
-                .from(new SimpleDateFormat("dd/MM/yy").parse("01/" + fromDate))
-                .to(new SimpleDateFormat("dd/MM/yy").parse("01/" + toDate))
-                .build();
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
-
-        MainController main = new MainController(shellRequest);
-        String serializedOutput = main.execute();
-        System.out.println(serializedOutput);
-
-        // TODO : return console / file / etc.. output
-        return true;
+    public ShellUserComponent() {
+        super(OptionType.USER);
     }
-
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/configuration/CommandConfiguration.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/configuration/CommandConfiguration.java
@@ -1,7 +1,9 @@
 package io.pakland.mdas.githubstats.infrastructure.shell.configuration;
 
+import io.pakland.mdas.githubstats.infrastructure.shell.components.ShellOrganizationComponent;
 import io.pakland.mdas.githubstats.infrastructure.shell.components.ShellTeamComponent;
 import io.pakland.mdas.githubstats.infrastructure.shell.components.ShellUserComponent;
+import io.pakland.mdas.githubstats.infrastructure.shell.model.CommandRegistrationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.shell.command.CommandRegistration;
@@ -9,81 +11,31 @@ import org.springframework.shell.command.CommandRegistration;
 @Configuration
 public class CommandConfiguration {
 
+
     @Bean
     public CommandRegistration buildUserCommand() {
-        ShellUserComponent shellUserComponent = new ShellUserComponent();
-
-        return CommandRegistration.builder()
-                .command("user")
-                .description("Get data from a specified user.")
-            .withTarget()
-                .method(shellUserComponent, "user")
-                .and()
-            .withOption()
-                .shortNames('n')
-                .longNames("name")
-                .label("USER_NAME")
-                .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
-                .type(String.class)
-                .required()
-                .and()
-            .withOption()
-                .shortNames('k')
-                .longNames("key")
-                .label("API_KEY")
-                .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
-                .type(String.class)
-                .required()
-                .and()
-            .withOption()
-                .longNames("from")
-                .label("FROM_DATE")
-                .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
-                .type(String.class)
-                .required()
-                .and()
-            .withOption()
-                .longNames("to")
-                .label("TO_DATE")
-                .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
-                .type(String.class)
-                .required()
-                .and()
-            .build();
+        return new CommandRegistrationBuilder(
+            "user",
+            "Load data from the specified user",
+            "<user-name>"
+        ).build(new ShellUserComponent());
     }
 
     @Bean
     public CommandRegistration buildTeamCommand() {
-        ShellTeamComponent shellTeamComponent = new ShellTeamComponent();
+        return new CommandRegistrationBuilder(
+            "team",
+            "Load data from all users of the specified team",
+            "<team-name>"
+        ).build(new ShellTeamComponent());
+    }
 
-        return CommandRegistration.builder()
-                .command("team")
-                .description("Get data from a specified team and its sub teams.")
-            .withTarget()
-                .method(shellTeamComponent, "team")
-                .and()
-            .withOption()
-                .shortNames('n')
-                .longNames("name")
-                .label("TEAM_NAME")
-                .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
-                .type(String.class)
-                .required()
-                .and()
-            .withOption()
-                .longNames("from")
-                .label("FROM_DATE")
-                .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
-                .type(String.class)
-                .required()
-                .and()
-            .withOption()
-                .longNames("to")
-                .label("TO_DATE")
-                .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
-                .type(String.class)
-                .required()
-                .and()
-            .build();
+    @Bean
+    public CommandRegistration buildUserComponent() {
+        return new CommandRegistrationBuilder(
+            "organization",
+            "Load data from all users of the specified organization, grouped by their team",
+            "<organization-name>"
+        ).build(new ShellOrganizationComponent());
     }
 }

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/configuration/CommandConfiguration.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/configuration/CommandConfiguration.java
@@ -31,7 +31,7 @@ public class CommandConfiguration {
     }
 
     @Bean
-    public CommandRegistration buildUserComponent() {
+    public CommandRegistration buildOrganizationCommand() {
         return new CommandRegistrationBuilder(
             "organization",
             "Load data from all users of the specified organization, grouped by their team",

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/model/CommandRegistrationBuilder.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/model/CommandRegistrationBuilder.java
@@ -1,0 +1,61 @@
+package io.pakland.mdas.githubstats.infrastructure.shell.model;
+
+import io.pakland.mdas.githubstats.infrastructure.shell.components.ShellComponent;
+import org.springframework.shell.command.CommandRegistration;
+
+public class CommandRegistrationBuilder {
+
+    private final String command;
+    private final String description;
+    private final String nameLabel;
+
+    public CommandRegistrationBuilder(String command, String description, String nameLabel) {
+        this.command = command;
+        this.description = description;
+        this.nameLabel = nameLabel;
+    }
+
+    public CommandRegistration build(ShellComponent shellComponent) {
+        return CommandRegistration.builder()
+            .command(this.command)
+            .description(this.description)
+            .withTarget()
+            .method(shellComponent, "run")
+            .and()
+            .withOption()
+            .shortNames('n')
+            .longNames("name")
+            .label(this.nameLabel)
+            .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
+            .type(String.class)
+            .required()
+            .and()
+            .withOption()
+            .shortNames('k')
+            .longNames("key")
+            .label("API_KEY")
+            .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
+            .type(String.class)
+            .required()
+            .and()
+            .withOption()
+            .longNames("from")
+            .label("<from-date>")
+            .description(
+                "Date should be entered as MM/yy. We will parse the date to match the first day of the given month.")
+            .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
+            .type(String.class)
+            .required()
+            .and()
+            .withOption()
+            .longNames("to")
+            .label("<to-date>")
+            .description(
+                "Date should be entered as MM/yy. We will parse the date to match the first day of the given month.")
+            .arity(CommandRegistration.OptionArity.EXACTLY_ONE)
+            .type(String.class)
+            .required()
+            .and()
+            .build();
+    }
+}

--- a/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/model/ShellRequest.java
+++ b/src/main/java/io/pakland/mdas/githubstats/infrastructure/shell/model/ShellRequest.java
@@ -1,6 +1,6 @@
 package io.pakland.mdas.githubstats.infrastructure.shell.model;
 
-import io.pakland.mdas.githubstats.domain.EntityType;
+import io.pakland.mdas.githubstats.domain.OptionType;
 import lombok.Builder;
 import lombok.Data;
 
@@ -12,7 +12,7 @@ public class ShellRequest {
 
     private String apiKey;
 
-    private EntityType entityType;
+    private OptionType entityType;
 
     private String name;
 


### PR DESCRIPTION
### Description

Added the fact of taking into account the different options that the user can choose (organization, team, user). Now, we only:

- Fetch all organizations if the user has not entered the organization option. Otherwise, we filter the fetched organizations so that we only get the data from the wanted organization.
- Fetch all teams if the user has not entered the team option. Otherwise, we filter the fetched teams so that we only get the data from the wanted team.
- Fetch all reviews and comments, to later filter them by user if the user option has been chosen (keep them all otherwise).

When analising the responses we were getting from fetching comments and reviews, we realises that the current implementation of the aggregation of reviews was not viable because it required an extra join that was not being done.  
We have also taken the oportunity (@manerow and I) to fix such code, clean it and ensure it works as expected. 

We are reaching the end 🎉🤞

Closes #192